### PR TITLE
Allow den_signs override

### DIFF
--- a/src/canvas/densitycanvas.jl
+++ b/src/canvas/densitycanvas.jl
@@ -1,4 +1,4 @@
-const den_signs = [" ", "░", "▒", "▓", "█"]
+const den_signs = Ref([" ", "░", "▒", "▓", "█"])
 
 """
 Unlike the `BrailleCanvas`, the density canvas
@@ -69,11 +69,12 @@ end
 
 function printrow(io::IO, c::DensityCanvas, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    signs = den_signs[]
     y = row
-    den_sign_count = length(den_signs)
+    den_sign_count = length(signs)
     val_scale = (den_sign_count - 1) / c.max_density
     for x in 1:ncols(c)
         den_index = round(Int, c.grid[x,y] * val_scale, RoundNearestTiesUp) + 1
-        print_color(c.colors[x,y], io, den_signs[den_index])
+        print_color(c.colors[x,y], io, signs[den_index])
     end
 end


### PR DESCRIPTION
```julia
using UnicodePlots

function tile(α)
  io = IOBuffer()
  color = round(Int64, 255α)
  if α < 0
      code = "\x1b[38;2;$(-color);0;0m"
  else
      code = "\x1b[38;2;0;0;$(color)m"
  end
  endc = "\x1b[0m"
  print(IOContext(io, :color => true), code, "█", endc)
  return String(take!(io))
end

main() = begin
  UnicodePlots.den_signs[] = [tile(i) for i ∈ range(-1, 1, length=40)]
  show(densityplot(randn(1000), randn(1000)))
  return
end

main()
```

Fix https://github.com/JuliaPlots/UnicodePlots.jl/issues/77.