### PR TITLE
Save space by moving labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,14 @@ parameters.
 
     Plotting range for the y coordinate
 
-- `margin::Int = 3`:
+- `labels::Bool = true`:
 
-    Number of empty characters to the left of the whole plot.
+    Can be used to hide the labels by setting `labels=false`.
+
+  ```julia
+  lineplot(sin, 1:.5:20, labels=false)
+  ```
+    ![Labels Screenshot](https://github.com/JuliaPlots/UnicodePlots.jl/raw/unicodeplots-docs/doc/imgs/2.x/labels.png)
 
 - `border::Symbol = :solid`:
 
@@ -246,18 +251,17 @@ parameters.
   ```
   ![Border Screenshot4](https://github.com/JuliaPlots/UnicodePlots.jl/raw/unicodeplots-docs/doc/imgs/2.x/border_none.png)
 
+- `compact::Bool = false`:
+    
+    Compact plot (labels), defaults to `false`.
+
+- `margin::Int = 3`:
+
+    Number of empty characters to the left of the whole plot.
+
 - `padding::Int = 1`:
 
     Space of the left and right of the plot between the labels and the canvas.
-
-- `labels::Bool = true`:
-
-    Can be used to hide the labels by setting `labels=false`.
-
-  ```julia
-  lineplot(sin, 1:.5:20, labels=false)
-  ```
-    ![Labels Screenshot](https://github.com/JuliaPlots/UnicodePlots.jl/raw/unicodeplots-docs/doc/imgs/2.x/labels.png)
 
 - `grid::Bool = true`:
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -16,6 +16,8 @@ const DOC_PLOT_PARAMS = """
   Supports `:corners`, `:solid`, `:bold`, `:dashed`, `:dotted`,
   `:ascii`, and `:none`.
 
+- **`compact`** : Compact plot (labels), defaults to `false`.
+
 - **`margin`** : Number of empty characters to the left of the
   whole plot.
 


### PR DESCRIPTION
When using `xlabel` and `ylabel`, use `label!` to save up space (especially width), when new keyword `compact=true` (default).
This is mostly useful when `min/max` strings are long (e.g. when using a scale), in conjunction with a long `ylabel`.
The height save is marginal (one line).

Example:
```julia
using UnicodePlots
x = y = collect(9:101);
lineplot(x, y, xlabel="x", ylabel="a very, very long label", xscale=:log10, yscale=:log10)
```

**before**
![before](https://user-images.githubusercontent.com/13423344/133793030-8c17af04-654c-4c1f-a237-36e6604903b4.png)

**after**
![after](https://user-images.githubusercontent.com/13423344/133793101-9ed0a9cf-c2b6-40ef-9fe2-256cc370216d.png)

One can always restore the previous behavior by toggling the `compact=false` keyword:
```julia
lineplot(x, y, xlabel="x", ylabel="a very, very long label", xscale=:log10, yscale=:log10, compact=false)
```
