### PR TITLE
Force color in tests for `PkgEval`

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -268,17 +268,10 @@ function crayon_256_color(color::UserColorType)::ColorType
     Crayons.val(ansicolor)
 end
 
-function julia_color(color::UserColorType)::JuliaColorType
-    if color isa Nothing
-        :normal
-    elseif color isa Symbol
-        color
-    elseif color isa Integer
-        Int(color)
-    else
-        julia_color(crayon_256_color(color))
-    end
-end
+julia_color(color::Integer)::JuliaColorType = Int(color)
+julia_color(color::Nothing)::JuliaColorType = :normal
+julia_color(color::Symbol)::JuliaColorType = color
+julia_color(color)::JuliaColorType = julia_color(crayon_256_color(color))
 
 @inline function set_color!(colors::Array{ColorType,2}, x::Int, y::Int, color::ColorType; force::Bool=false)
     if color === nothing || colors[x, y] === nothing || force

--- a/src/common.jl
+++ b/src/common.jl
@@ -5,32 +5,28 @@ const DOC_PLOT_PARAMS = """
 
 - **`ylabel`** : Text to display on the y axis of the plot
 
-- **`xscale`** : X-axis scale (:identity, :ln, :log2, :log10), or scale function e.g. `x -> log10(x)`
+- **`xscale`** : X-axis scale (:identity, :ln, :log2, :log10),
+  or scale function e.g. `x -> log10(x)`
 
 - **`yscale`** : Y-axis scale
 
-- **`labels`** : Boolean. Can be used to hide the labels by
-  setting `labels = false`.
+- **`labels`** : Boolean. Can be used to hide the labels by setting `labels = false`.
 
 - **`border`** : The style of the bounding box of the plot.
-  Supports `:corners`, `:solid`, `:bold`, `:dashed`, `:dotted`,
-  `:ascii`, and `:none`.
+  Supports `:corners`, `:solid`, `:bold`, `:dashed`, `:dotted`, `:ascii`, and `:none`.
 
 - **`compact`** : Compact plot (labels), defaults to `false`.
 
-- **`margin`** : Number of empty characters to the left of the
-  whole plot.
+- **`margin`** : Number of empty characters to the left of the whole plot.
 
-- **`padding`** : Space of the left and right of the plot between
-  the labels and the canvas.
+- **`padding`** : Space of the left and right of the plot between the labels and the canvas.
 
 - **`color`** : Color of the drawing.
-  Can be any of `:green`, `:blue`, `:red`, `:yellow`, `:cyan`,
-  `:magenta`, `:white`, `:normal`, an integer in the range `0`-`255` for Color256 palette,
+  Can be any of `:green`, `:blue`, `:red`, `:yellow`, `:cyan`, `:magenta`, `:white`,
+  `:normal`, an integer in the range `0`-`255` for Color256 palette,
   or a tuple of three integers as RGB components.
 
-- **`width`** : Number of characters per row that should be used
-  for plotting.
+- **`width`** : Number of characters per row that should be used for plotting.
 """
 
 const MarkerType = Union{Symbol,Char,AbstractString}
@@ -57,7 +53,7 @@ const MARKERS = (
 )
 
 function char_marker(marker::MarkerType)::Char
-    m = if marker isa Symbol
+    if marker isa Symbol
         get(MARKERS, marker, MARKERS[:circle])
     else
         length(marker) == 1 || throw(error("`marker` keyword has a non unit length"))
@@ -155,97 +151,107 @@ function sorted_keys_values(dict::Dict; k2s=true)
     first.(keys_vals), last.(keys_vals)
 end
 
-const bordermap = Dict{Symbol,Dict{Symbol,Char}}()
-const border_solid  = Dict{Symbol,Char}()
-const border_corners = Dict{Symbol,Char}()
-const border_barplot = Dict{Symbol,Char}()
-const border_bold   = Dict{Symbol,Char}()
-const border_bnone = Dict{Symbol,Char}()
-const border_none   = Dict{Symbol,Char}()
-const border_dashed = Dict{Symbol,Char}()
-const border_dotted = Dict{Symbol,Char}()
-const border_ascii  = Dict{Symbol,Char}()
-border_solid[:tl] = '┌'
-border_solid[:tr] = '┐'
-border_solid[:bl] = '└'
-border_solid[:br] = '┘'
-border_solid[:t] = '─'
-border_solid[:l] = '│'
-border_solid[:b] = '─'
-border_solid[:r] = '│'
-border_corners[:tl] = '┌'
-border_corners[:tr] = '┐'
-border_corners[:bl] = '└'
-border_corners[:br] = '┘'
-border_corners[:t] = ' '
-border_corners[:l] = ' '
-border_corners[:b] = ' '
-border_corners[:r] = ' '
-border_barplot[:tl] = '┌'
-border_barplot[:tr] = '┐'
-border_barplot[:bl] = '└'
-border_barplot[:br] = '┘'
-border_barplot[:t] = ' '
-border_barplot[:l] = '┤'
-border_barplot[:b] = ' '
-border_barplot[:r] = ' '
-border_bold[:tl] = '┏'
-border_bold[:tr] = '┓'
-border_bold[:bl] = '┗'
-border_bold[:br] = '┛'
-border_bold[:t] = '━'
-border_bold[:l] = '┃'
-border_bold[:b] = '━'
-border_bold[:r] = '┃'
-border_bnone[:tl] = Char(0x2800)
-border_bnone[:tr] = Char(0x2800)
-border_bnone[:bl] = Char(0x2800)
-border_bnone[:br] = Char(0x2800)
-border_bnone[:t] = Char(0x2800)
-border_bnone[:l] = Char(0x2800)
-border_bnone[:b] = Char(0x2800)
-border_bnone[:r] = Char(0x2800)
-border_none[:tl] = ' '
-border_none[:tr] = ' '
-border_none[:bl] = ' '
-border_none[:br] = ' '
-border_none[:t] = ' '
-border_none[:l] = ' '
-border_none[:b] = ' '
-border_none[:r] = ' '
-border_dashed[:tl] = '┌'
-border_dashed[:tr] = '┐'
-border_dashed[:bl] = '└'
-border_dashed[:br] = '┘'
-border_dashed[:t] = '╌'
-border_dashed[:l] = '┊'
-border_dashed[:b] = '╌'
-border_dashed[:r] = '┊'
-border_dotted[:tl] = '⡤'
-border_dotted[:tr] = '⢤'
-border_dotted[:bl] = '⠓'
-border_dotted[:br] = '⠚'
-border_dotted[:t] = '⠤'
-border_dotted[:l] = '⡇'
-border_dotted[:b] = '⠒'
-border_dotted[:r] = '⢸'
-border_ascii[:tl] = '+'
-border_ascii[:tr] = '+'
-border_ascii[:bl] = '+'
-border_ascii[:br] = '+'
-border_ascii[:t] = '-'
-border_ascii[:l] = '|'
-border_ascii[:b] = '-'
-border_ascii[:r] = '|'
-bordermap[:solid]   = border_solid
-bordermap[:corners] = border_corners
-bordermap[:barplot] = border_barplot
-bordermap[:bold]    = border_bold
-bordermap[:none]    = border_none
-bordermap[:bnone]   = border_bnone
-bordermap[:dashed]  = border_dashed
-bordermap[:dotted]  = border_dotted
-bordermap[:ascii]   = border_ascii
+const border_solid = (
+    tl = '┌',
+    tr = '┐',
+    bl = '└',
+    br = '┘',
+    t = '─',
+    l = '│',
+    b = '─',
+    r = '│',
+)
+const border_corners = (
+    tl = '┌',
+    tr = '┐',
+    bl = '└',
+    br = '┘',
+    t = ' ',
+    l = ' ',
+    b = ' ',
+    r = ' ',
+)
+const border_barplot = (
+    tl = '┌',
+    tr = '┐',
+    bl = '└',
+    br = '┘',
+    t = ' ',
+    l = '┤',
+    b = ' ',
+    r = ' ',
+)
+const border_bold = (
+    tl = '┏',
+    tr = '┓',
+    bl = '┗',
+    br = '┛',
+    t = '━',
+    l = '┃',
+    b = '━',
+    r = '┃',
+)
+const border_none = (
+    tl = ' ',
+    tr = ' ',
+    bl = ' ',
+    br = ' ',
+    t = ' ',
+    l = ' ',
+    b = ' ',
+    r = ' ',
+)
+const border_bnone = (
+    tl = Char(0x2800),
+    tr = Char(0x2800),
+    bl = Char(0x2800),
+    br = Char(0x2800),
+    t = Char(0x2800),
+    l = Char(0x2800),
+    b = Char(0x2800),
+    r = Char(0x2800),
+)
+const border_dashed = (
+    tl = '┌',
+    tr = '┐',
+    bl = '└',
+    br = '┘',
+    t = '╌',
+    l = '┊',
+    b = '╌',
+    r = '┊',
+)
+const border_dotted = (
+    tl = '⡤',
+    tr = '⢤',
+    bl = '⠓',
+    br = '⠚',
+    t = '⠤',
+    l = '⡇',
+    b = '⠒',
+    r = '⢸',
+)
+const border_ascii = (
+    tl = '+',
+    tr = '+',
+    bl = '+',
+    br = '+',
+    t = '-',
+    l = '|',
+    b = '-',
+    r = '|',
+)
+const bordermap = (
+    solid   = border_solid,
+    corners = border_corners,
+    barplot = border_barplot,
+    bold    = border_bold,
+    none    = border_none,
+    bnone   = border_bnone,
+    dashed  = border_dashed,
+    dotted  = border_dotted,
+    ascii   = border_ascii,
+)
 
 const UserColorType = Union{Integer,Symbol,NTuple{3,Integer},Nothing}  # allowed color type
 const JuliaColorType = Union{Symbol,Int}  # color type for printstyled (defined in base/util.jl)
@@ -288,9 +294,9 @@ out_stream_height(out_stream::Union{Nothing,IO})::Int = out_stream_size(out_stre
 
 function _handle_deprecated_symb(symb, symbols)
     if symb === nothing
-        return symbols
+        symbols
     else
         Base.depwarn("The keyword `symb` is deprecated in favor of `symbols`", :BarplotGraphics)
-        return [symb]
+        [symb]
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ tests = [
 ]
 
 const RNG = StableRNG(1337)
-const T_SZ = (24, 80)
+const T_SZ = (24, 80)  # terminal size
 
 # see JuliaTesting/ReferenceTests.jl/pull/91
 test_ref(reference, actual) = @test_reference(reference, actual, render = BeforeAfterFull(), format = "TXT")
@@ -57,8 +57,10 @@ function stable_sprand(r::AbstractRNG, m::Integer, n::Integer, density::Abstract
   sparse(I, J, V)
 end
 
-for test in tests
-    @testset "$test" begin
-        include(test)
+withenv("FORCE_COLOR"=>"X") do  # github.com/JuliaPlots/UnicodePlots.jl/issues/134
+    for test in tests
+        @testset "$test" begin
+            include(test)
+        end
     end
 end

--- a/test/tst_common.jl
+++ b/test/tst_common.jl
@@ -39,7 +39,8 @@ end
 end
 
 @testset "bordermap" begin
-    @test length(keys(UnicodePlots.bordermap)) == 9
+    bmap_keys = keys(UnicodePlots.bordermap)
+    @test length(bmap_keys) == 9
     @test haskey(UnicodePlots.bordermap, :none)
     @test haskey(UnicodePlots.bordermap, :bnone)
     @test haskey(UnicodePlots.bordermap, :solid)
@@ -49,7 +50,7 @@ end
     @test haskey(UnicodePlots.bordermap, :dotted)
     @test haskey(UnicodePlots.bordermap, :dashed)
     @test haskey(UnicodePlots.bordermap, :ascii)
-    for (k, v) in UnicodePlots.bordermap
+    for (k, v) in zip(bmap_keys, UnicodePlots.bordermap)
         @test length(keys(v)) == 8
         @test haskey(v, :tl)
         @test haskey(v, :tr)


### PR DESCRIPTION
- Fix https://github.com/JuliaPlots/UnicodePlots.jl/issues/134.

```bash
$ julia --color=yes -e 'using Pkg; pkg"test UnicodePlots"'
$ julia --color=no  -e 'using Pkg; pkg"test UnicodePlots"'
```
, until https://github.com/KristofferC/Crayons.jl/issues/47 is fixed.

- Code cleanup, use `NamedTuple` instead of `Dict` (faster):

**before**
```julia
julia> using UnicodePlots
julia> @time lineplot([0, 4, 8], [10, 1, 10], color = :blue, name = "other line")
  1.096257 seconds (858.07 k allocations: 52.733 MiB, 4.19% gc time, 99.74% compilation time)
julia> @time lineplot([0, 4, 8], [10, 1, 10], color = :blue, name = "other line")
  0.000232 seconds (1.09 k allocations: 29.000 KiB)
```

**after**
```julia
julia> using UnicodePlots
@time lineplot([0, 4, 8], [10, 1, 10], color = :blue, name = "other line")
  0.922900 seconds (857.27 k allocations: 52.692 MiB, 1.76% gc time, 99.84% compilation time)
@time lineplot([0, 4, 8], [10, 1, 10], color = :blue, name = "other line")
  0.000172 seconds (1.09 k allocations: 29.000 KiB)
```