### PR TITLE
Ease making canvas invisible

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -179,8 +179,8 @@ function Plot(
 ) where {C<:Canvas}
     length(xlim) == length(ylim) == 2 ||
         throw(ArgumentError("xlim and ylim must be tuples or vectors of length 2"))
-    length(X) == length(Y) || throw(DimensionMismatch("X and Y must be the same length"))
-    width = max(width, min_width)
+    length(X) == length(Y) || throw(DimensionMismatch("X and Y must have same length"))
+    (visible = width > 0) && (width = max(width, min_width))
     height = max(height, min_height)
 
     min_x, max_x = extend_limits(X, xlim, xscale)
@@ -193,7 +193,7 @@ function Plot(
         width,
         height,
         blend = blend,
-        visible = width > 0 && height > 0,
+        visible = visible,
         origin_x = min_x,
         origin_y = min_y,
         width = p_width,

--- a/test/tst_issues.jl
+++ b/test/tst_issues.jl
@@ -19,14 +19,7 @@
     end
 
     @testset "isolated colorbar (#169)" begin
-        p = @inferred Plot(
-            [0],
-            [0],
-            colorbar = true,
-            colormap = :cividis,
-            width = 0,
-            min_width = 0,
-        )
+        p = @inferred Plot([0], [0], colorbar = true, colormap = :cividis, width = 0)
         test_ref("references/issues/isolated_colorbar.txt", @show_col(p))
     end
 end

--- a/test/tst_plot.jl
+++ b/test/tst_plot.jl
@@ -145,3 +145,8 @@ end
         annotate!(p, 0, 0, "Origin"; halign = h, valign = v)
     end
 end
+
+@testset "invisible" begin
+    p = Plot([0], [0], width = 0)
+    @test !p.graphics.visible
+end


### PR DESCRIPTION
Slight followup of https://github.com/JuliaPlots/UnicodePlots.jl/pull/205, where we now use `width = 0` to make the canvas disappear (`visible` = false).

We need this to make blank plots disappear in `Plots.jl` layouts.