### PR TITLE
Reduce allocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.jl.cov
 *.jl.mem
+*.mem
 *.cov
 *.swp
 

--- a/src/interface/isosurface.jl
+++ b/src/interface/isosurface.jl
@@ -138,5 +138,5 @@ function isosurface!(
         end
     end
     # triangles vertices or centroid
-    scatterplot!(plot, xs, ys, zs; color = cs)
+    points!(plot, xs, ys, zs, cs)
 end

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -283,7 +283,7 @@ function transform_matrix(t::MVP, n::Symbol)
     end
 end
 
-is_ortho(t::MVP, n::Symbol) = (
+function is_ortho(t::MVP, n::Symbol)
     if n === :user
         t.ortho
     elseif n === :orthographic
@@ -293,7 +293,7 @@ is_ortho(t::MVP, n::Symbol) = (
     else
         throw(ArgumentError("invalid n=$n"))
     end
-)
+end
 
 function (t::MVP{T})(p::AbstractMatrix, n::Symbol = :user) where {T}
     # homogeneous coordinates

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -279,8 +279,8 @@ is_ortho(t::MVP, n::Symbol) = (user = t.ortho, orthographic = true, perspective 
 function (t::MVP{T})(p::AbstractMatrix, n::Symbol = :user) where {T}
     # homogeneous coordinates
     dat = transform_matrix(t, n) * (size(p, 1) == 4 ? p : vcat(p, ones(1, size(p, 2))))
-    xs, ys, zs, ws = dat[1, :], dat[2, :], dat[3, :], dat[4, :]
-    @inbounds for (i, w) in enumerate(ws)
+    xs, ys, zs = dat[1, :], dat[2, :], dat[3, :]
+    @inbounds for (i, w) in enumerate(@view(dat[4, :]))
         if abs(w) > eps(T)
             xs[i] /= w
             ys[i] /= w

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -271,23 +271,47 @@ struct MVP{T}
     end
 end
 
-transform_matrix(t::MVP, n::Symbol) =
-    (user = t.mvp_mat, orthographic = t.mvp_ortho_mat, perspective = t.mvp_persp_mat)[n]
+transform_matrix(t::MVP, n::Symbol) = (
+    if n === :user
+        t.mvp_mat
+    elseif n === :orthographic
+        t.mvp_ortho_mat
+    elseif n === :perspective
+        t.mvp_persp_mat
+    else
+        throw(ArgumentError("invalid n=$n"))
+    end
+)
 
-is_ortho(t::MVP, n::Symbol) = (user = t.ortho, orthographic = true, perspective = false)[n]
+is_ortho(t::MVP, n::Symbol) = (
+    if n === :user
+        t.ortho
+    elseif n === :orthographic
+        true
+    elseif n === :perspective
+        false
+    else
+        throw(ArgumentError("invalid n=$n"))
+    end
+)
 
 function (t::MVP{T})(p::AbstractMatrix, n::Symbol = :user) where {T}
     # homogeneous coordinates
     dat = transform_matrix(t, n) * (size(p, 1) == 4 ? p : vcat(p, ones(1, size(p, 2))))
     xs, ys, zs = dat[1, :], dat[2, :], dat[3, :]
+    persp = !is_ortho(t, n)
     @inbounds for (i, w) in enumerate(@view(dat[4, :]))
         if abs(w) > eps(T)
             xs[i] /= w
             ys[i] /= w
             zs[i] /= w
         end
+        if persp
+            xs[i] /= zs[i]
+            ys[i] /= zs[i]
+        end
     end
-    is_ortho(t, n) ? (xs, ys) : (xs ./ zs, ys ./ zs)
+    xs, ys
 end
 
 function (t::MVP{T})(v::Union{AbstractVector,NTuple{3}}, n::Symbol = :user) where {T}

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -271,7 +271,7 @@ struct MVP{T}
     end
 end
 
-transform_matrix(t::MVP, n::Symbol) = (
+function transform_matrix(t::MVP, n::Symbol)
     if n === :user
         t.mvp_mat
     elseif n === :orthographic
@@ -281,7 +281,7 @@ transform_matrix(t::MVP, n::Symbol) = (
     else
         throw(ArgumentError("invalid n=$n"))
     end
-)
+end
 
 is_ortho(t::MVP, n::Symbol) = (
     if n === :user

--- a/test/tst_volume.jl
+++ b/test/tst_volume.jl
@@ -42,6 +42,16 @@
     @test length(T([1, 2, 3])) == 2
     @test length(T((1, 2, 3))) == 2
 
+    @test UnicodePlots.transform_matrix(T, :user) isa AbstractMatrix
+    @test UnicodePlots.transform_matrix(T, :orthographic) isa AbstractMatrix
+    @test UnicodePlots.transform_matrix(T, :perspective) isa AbstractMatrix
+    @test_throws ArgumentError UnicodePlots.transform_matrix(T, :not_supported)
+
+    @test UnicodePlots.is_ortho(T, :user)
+    @test UnicodePlots.is_ortho(T, :orthographic)
+    @test !UnicodePlots.is_ortho(T, :perspective)
+    @test_throws ArgumentError UnicodePlots.is_ortho(T, :not_supported)
+
     corners = UnicodePlots.cube_corners(-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
     @test size(corners) == (3, 8)
     @test all(-1 .<= corners .<= 1)


### PR DESCRIPTION
When doing 3D, transforming points is quite costly in terms of allocations. Maybe I'll find time to rewrite the whole transform thing by preallocating (which will certainly be a tradeoff for readability), but for now small improvements like the following are unavoidable.

**master**
```julia
julia> using BenchmarkTools, UnicodePlots
julia> @btime surfaceplot(-8:.5:8, -8:.5:8, (x, y) -> 15sinc(√(x^2 + y^2) / π), lines=true);
  32.321 ms (266809 allocations: 16.65 MiB)
```

**pr**
```julia
julia> using BenchmarkTools, UnicodePlots
julia> @btime surfaceplot(-8:.5:8, -8:.5:8, (x, y) -> 15sinc(√(x^2 + y^2) / π), lines=true);
  27.441 ms (233254 allocations: 11.25 MiB)
```