### PR TITLE
Save `Plot` as `png`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,8 @@ version = "2.9.0"
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+FreeTypeAbstraction = "663a7486-cb36-511b-a19d-713bb74d65c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MarchingCubes = "299715c1-40a9-479a-aaf9-4a633d36f717"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
@@ -20,6 +22,8 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 Contour = "0.5"
 Crayons = "4.1"
+FileIO = "1"
+FreeTypeAbstraction = "0.9"
 MarchingCubes = "0.1"
 NaNMath = "0.3, 1"
 StaticArrays = "0.12, 1"
@@ -29,10 +33,11 @@ julia = "1.6"
 
 [extras]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["ColorTypes", "ReferenceTests", "StableRNGs", "Random", "Test"]
+test = ["ColorTypes", "ImageMagick", "ReferenceTests", "StableRNGs", "Random", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ authors = ["Christof Stocker <stocker.christof@gmail.com>", "T Bltg <tf.bltg@gma
 version = "2.9.0"
 
 [deps]
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Contour = "d38c429a-6771-53c6-b99e-75d170b6e991"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -20,6 +21,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
+ColorTypes = "0.10, 0.11"
 Contour = "0.5"
 Crayons = "4.1"
 FileIO = "1"

--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -13,6 +13,7 @@ import NaNMath
 import Contour
 
 import FreeTypeAbstraction
+import ColorTypes
 import FileIO
 
 export GraphicsArea,

--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -12,6 +12,9 @@ import MarchingCubes
 import NaNMath
 import Contour
 
+import FreeTypeAbstraction
+import FileIO
+
 export GraphicsArea,
     Canvas,
     BrailleCanvas,

--- a/src/canvas.jl
+++ b/src/canvas.jl
@@ -273,8 +273,10 @@ function annotate!(c::Canvas, x::Number, y::Number, text::Char, color::UserColor
     c
 end
 
-function printcolorbarrow(
+function print_colorbar_row(
     io::IO,
+    print_nc,
+    print_col,
     c::Canvas,
     row::Int,
     colormap::Function,
@@ -293,18 +295,18 @@ function printcolorbarrow(
     if row == 1
         label = lim_str[2]
         # print top border and maximum z value
-        print_color(io, bc, b[:tl], b[:t], b[:t], b[:tr])
-        print(io, plot_padding)
-        print_color(io, bc, label)
+        print_col(io, bc, b[:tl], b[:t], b[:t], b[:tr])
+        print_nc(io, plot_padding)
+        print_col(io, bc, label)
     elseif row == nrows(c)
         label = lim_str[1]
         # print bottom border and minimum z value
-        print_color(io, bc, b[:bl], b[:b], b[:b], b[:br])
-        print(io, plot_padding)
-        print_color(io, bc, label)
+        print_col(io, bc, b[:bl], b[:b], b[:b], b[:br])
+        print_nc(io, plot_padding)
+        print_col(io, bc, label)
     else
         # print gradient
-        print_color(io, bc, b[:l])
+        print_col(io, bc, b[:l])
         if min_z == max_z  # if min and max are the same, single color
             fgcol = bgcol = colormap(1, 1, 1)
         else  # otherwise, blend from min to max
@@ -313,15 +315,15 @@ function printcolorbarrow(
             fgcol = colormap(n - 2r - 1, 1, n)
             bgcol = colormap(n - 2r, 1, n)
         end
-        print_color(io, fgcol, HALF_BLOCK, HALF_BLOCK; bgcol = bgcol)
-        print_color(io, bc, b[:r])
-        print(io, plot_padding)
+        print_col(io, fgcol, HALF_BLOCK, HALF_BLOCK; bgcol = bgcol)
+        print_col(io, bc, b[:r])
+        print_nc(io, plot_padding)
         # print z label
         if row == div(nrows(c), 2) + 1
             label = zlabel
-            print(io, label)
+            print_nc(io, label)
         end
     end
-    print(io, repeat(blank, max_len - length(label)))
+    print_nc(io, repeat(blank, max_len - length(label)))
     nothing
 end

--- a/src/canvas/braillecanvas.jl
+++ b/src/canvas/braillecanvas.jl
@@ -114,11 +114,11 @@ function char_point!(
     c
 end
 
-function printrow(io::IO, c::BrailleCanvas, row::Int)
+function printrow(io::IO, print_nc, print_col, c::BrailleCanvas, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     y = row
     for x in 1:ncols(c)
-        print_color(io, c.colors[x, y], c.grid[x, y])
+        print_col(io, c.colors[x, y], c.grid[x, y])
     end
     nothing
 end

--- a/src/canvas/densitycanvas.jl
+++ b/src/canvas/densitycanvas.jl
@@ -93,7 +93,7 @@ function pixel!(c::DensityCanvas, pixel_x::Int, pixel_y::Int, color::UserColorTy
     c
 end
 
-function printrow(io::IO, c::DensityCanvas, row::Int)
+function printrow(io::IO, print_nc, print_col, c::DensityCanvas, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     signs = den_signs[]
     y = row
@@ -101,7 +101,7 @@ function printrow(io::IO, c::DensityCanvas, row::Int)
     val_scale = (den_sign_count - 1) / c.max_density
     for x in 1:ncols(c)
         den_index = round(Int, c.grid[x, y] * val_scale, RoundNearestTiesUp) + 1
-        print_color(io, c.colors[x, y], signs[den_index])
+        print_col(io, c.colors[x, y], signs[den_index])
     end
     nothing
 end

--- a/src/canvas/heatmapcanvas.jl
+++ b/src/canvas/heatmapcanvas.jl
@@ -44,7 +44,7 @@ function HeatmapCanvas(args...; kw...)
     c
 end
 
-function printrow(io::IO, c::HeatmapCanvas, row::Int)
+function printrow(io::IO, print_nc, print_col, c::HeatmapCanvas, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     y = 2row
 
@@ -54,7 +54,7 @@ function printrow(io::IO, c::HeatmapCanvas, row::Int)
     for x in 1:ncols(c)
         # for odd numbers of rows, only print the foreground for the top row
         bgcol = y > 1 ? c.colors[x, y - 1] : missing
-        print_color(io, c.colors[x, y], HALF_BLOCK; bgcol = bgcol)
+        print_col(io, c.colors[x, y], HALF_BLOCK; bgcol = bgcol)
     end
 
     nothing

--- a/src/canvas/lookupcanvas.jl
+++ b/src/canvas/lookupcanvas.jl
@@ -106,11 +106,11 @@ function pixel!(
     c
 end
 
-function printrow(io::IO, c::LookupCanvas, row::Int)
+function printrow(io::IO, print_nc, print_col, c::LookupCanvas, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     y = row
     for x in 1:ncols(c)
-        print_color(io, colors(c)[x, y], lookup_decode(c)[grid(c)[x, y] + 1])
+        print_col(io, colors(c)[x, y], lookup_decode(c)[grid(c)[x, y] + 1])
     end
     nothing
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -416,6 +416,7 @@ function print_color(io::IO, color::ColorType, args...; bgcol = missing)
             args...,
         )
     end
+    nothing
 end
 
 @inline r32(r::Integer)::UInt32 = (r & 0xffffff) << 16

--- a/src/graphics.jl
+++ b/src/graphics.jl
@@ -9,25 +9,31 @@ suitable_color(c::GraphicsArea, color::Union{UserColorType,AbstractVector}) = an
     (color isa AbstractVector ? first(color) : color),
 )
 
-function Base.print(io::IO, c::GraphicsArea)
+Base.print(io::IO, c::GraphicsArea) = _print(io, print, print_color, c)
+
+function _print(io::IO, print_nc, print_col, c::GraphicsArea)
     for row in 1:nrows(c)
-        printrow(io, c, row)
-        row < nrows(c) && println(io)
+        printrow(io, print_nc, print_col, c, row)
+        row < nrows(c) && print_nc(io, '\n')
     end
     nothing
 end
 
-function Base.show(io::IO, c::GraphicsArea)
+Base.show(io::IO, c::GraphicsArea) = _show(io, print, print_color, c)
+
+function _show(io::IO, print_nc, print_col, c::GraphicsArea)
     b = BORDER_SOLID
     bc = BORDER_COLOR[]
     border_length = ncols(c)
-    print_border(io, :t, border_length, "", "\n", b, bc)
+    print_border(io, print_nc, print_col, :t, border_length, "", "\n", b, bc)
     for row in 1:nrows(c)
-        print_color(io, bc, b[:l])
-        printrow(io, c, row)
-        print_color(io, bc, b[:r])
-        row < nrows(c) && println(io)
+        print_col(io, bc, b[:l])
+        printrow(io, print_nc, print_col, c, row)
+        print_col(io, bc, b[:r])
+        row < nrows(c) && print_nc(io, '\n')
     end
-    print_border(io, :b, border_length, "\n", "", b, bc)
+    print_border(io, print_nc, print_col, :b, border_length, "\n", "", b, bc)
     nothing
 end
+
+printrow(io::IO, c::GraphicsArea, row::Int) = printrow(io, print, print_color, c, row)

--- a/src/graphics/bargraphics.jl
+++ b/src/graphics/bargraphics.jl
@@ -90,7 +90,7 @@ function addrow!(
     c
 end
 
-function printrow(io::IO, c::BarplotGraphics, row::Int)
+function printrow(io::IO, print_nc, print_col, c::BarplotGraphics, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument \"row\" out of bounds: $row"))
     bar = c.bars[row]
     max_val = c.maximum === nothing ? c.max_val : max(c.max_val, c.maximum)
@@ -99,20 +99,20 @@ function printrow(io::IO, c::BarplotGraphics, row::Int)
     nsyms = length(c.symbols)
     frac = float(max_val > 0 ? max(val, zero(val)) / max_val : 0)
     bar_head = round(Int, frac * max_bar_width, nsyms > 1 ? RoundDown : RoundNearestTiesUp)
-    print_color(io, c.colors[row], max_val > 0 ? repeat(c.symbols[nsyms], bar_head) : "")
+    print_col(io, c.colors[row], max_val > 0 ? repeat(c.symbols[nsyms], bar_head) : "")
     if nsyms > 1
         rem = (frac * max_bar_width - bar_head) * (nsyms - 2)
-        print_color(io, c.colors[row], rem > 0 ? c.symbols[1 + round(Int, rem)] : " ")
+        print_col(io, c.colors[row], rem > 0 ? c.symbols[1 + round(Int, rem)] : " ")
         bar_head += 1  # padding, we printed one more char
     end
     bar_lbl = string(bar)
     if bar >= 0
-        print_color(io, :normal, " ", bar_lbl)
+        print_col(io, :normal, " ", bar_lbl)
         len = length(bar_lbl)
     else
         len = -1
     end
     pad_len = max(max_bar_width + 1 + c.max_len - bar_head - len, 0)
-    print(io, ' '^round(Int, pad_len))
+    print_nc(io, ' '^round(Int, pad_len))
     nothing
 end

--- a/src/graphics/boxgraphics.jl
+++ b/src/graphics/boxgraphics.jl
@@ -86,7 +86,7 @@ function addseries!(
     c
 end
 
-function printrow(io::IO, c::BoxplotGraphics, row::Int)
+function printrow(io::IO, print_nc, print_col, c::BoxplotGraphics, row::Int)
     0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     idx = ceil(Int, row / 3)
     series = c.data[idx]
@@ -131,6 +131,6 @@ function printrow(io::IO, c::BoxplotGraphics, row::Int)
         line[i] = line_char
     end
 
-    print_color(io, c.colors[idx], join(line))
+    print_col(io, c.colors[idx], join(line))
     nothing
 end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -582,6 +582,8 @@ end
 
 function print_title(
     io::IO,
+    print_nc,
+    print_col,
     left_pad::AbstractString,
     title::AbstractString,
     right_pad::AbstractString,
@@ -589,39 +591,46 @@ function print_title(
     p_width::Int = 0,
     color::UserColorType = :normal,
 )
-    title == "" && return
+    title == "" && return (0, 0)
     offset = round(Int, p_width / 2 - length(title) / 2, RoundNearestTiesUp)
     pre_pad = repeat(blank, offset > 0 ? offset : 0)
-    print(io, left_pad, pre_pad)
-    print_color(io, color, title)
+    print_nc(io, left_pad, pre_pad)
+    print_col(io, color, title)
     post_pad = repeat(blank, max(0, p_width - length(pre_pad) - length(title)))
-    print(io, post_pad, right_pad)
-    nothing
+    print_nc(io, post_pad, right_pad)
+    (
+        count("\n", title) + 1,
+        length(strip(left_pad * pre_pad * title * post_pad * right_pad, '\n')),
+    )
 end
 
 function print_border(
     io::IO,
+    print_nc,
+    print_col,
     loc::Symbol,
     length::Int,
-    left_pad::AbstractString,
-    right_pad::AbstractString,
+    left_pad::Union{Char,AbstractString},
+    right_pad::Union{Char,AbstractString},
     bmap = BORDERMAP[:solid],
     color::UserColorType = BORDER_COLOR[],
 )
-    print(io, left_pad)
-    print_color(
+    print_nc(io, left_pad)
+    print_col(
         io,
         color,
         bmap[Symbol(loc, :l)],
         repeat(bmap[loc], length),
         bmap[Symbol(loc, :r)],
     )
-    print(io, right_pad)
+    print_nc(io, right_pad)
     nothing
 end
 
 function print_labels(
     io::IO,
+    print_nc,
+    print_col,
     mloc::Symbol,
     p::Plot,
     border_length,
@@ -643,22 +652,24 @@ function print_labels(
         left_len  = length(left_str)
         mid_len   = length(mid_str)
         right_len = length(right_str)
-        print(io, left_pad)
-        print_color(io, left_col, left_str)
+        print_nc(io, left_pad)
+        print_col(io, left_col, left_str)
         cnt = round(Int, border_length / 2 - mid_len / 2 - left_len, RoundNearestTiesAway)
         pad = cnt > 0 ? repeat(blank, cnt) : ""
-        print(io, pad)
-        print_color(io, mid_col, mid_str)
+        print_nc(io, pad)
+        print_col(io, mid_col, mid_str)
         cnt = border_length - right_len - left_len - mid_len + 2 - cnt
         pad = cnt > 0 ? repeat(blank, cnt) : ""
-        print(io, pad)
-        print_color(io, right_col, right_str)
-        print(io, right_pad)
+        print_nc(io, pad)
+        print_col(io, right_col, right_str)
+        print_nc(io, right_pad)
     end
     nothing
 end
 
-function Base.show(io::IO, p::Plot)
+Base.show(io::IO, p::Plot) = _show(io, print, print_color, p)
+
+function _show(io::IO, print_nc, print_col, p::Plot)
     c = p.graphics
     🗷 = Char(BLANK)  # blank outside canvas
     🗹 = Char(c isa BrailleCanvas ? BLANK_BRAILLE : 🗷)  # blank inside canvas
@@ -666,8 +677,9 @@ function Base.show(io::IO, p::Plot)
     # 🗷 = 'x'  # debug
     # 🗹 = Char(typeof(c) <: BrailleCanvas ? '⠿' : 'o')  # debug
     ############################################################
-    border_length = ncols(c)
-    p_width = border_length + 2  # left corner + border + right corner
+    nr = nrows(c)
+    nc = ncols(c)
+    p_width = nc + 2  # left corner + border length (number of canvas cols) + right corner
 
     bmap = BORDERMAP[p.border === :none && c isa BrailleCanvas ? :bnone : p.border]
 
@@ -710,8 +722,10 @@ function Base.show(io::IO, p::Plot)
     border_right_pad = repeat(🗷, max_len_r) * plot_padding * cbar_pad
 
     # plot the title and the top border
-    print_title(
+    h_ttl, w_ttl = print_title(
         io,
+        print_nc,
+        print_col,
         border_left_pad,
         p.title,
         border_right_pad * '\n',
@@ -721,15 +735,25 @@ function Base.show(io::IO, p::Plot)
     )
     print_labels(
         io,
+        print_nc,
+        print_col,
         :t,
         p,
-        border_length - 2,
+        nc - 2,
         border_left_pad * 🗹,
         🗹 * border_right_pad * '\n',
         🗹,
     )
-    c.visible &&
-        print_border(io, :t, border_length, border_left_pad, border_right_pad * '\n', bmap)
+    c.visible && print_border(
+        io,
+        print_nc,
+        print_col,
+        :t,
+        nc,
+        border_left_pad,
+        border_right_pad * '\n',
+        bmap,
+    )
 
     # compute position of ylabel
     y_lab_row = round(nrows(c) / 2, RoundNearestTiesUp)
@@ -739,9 +763,9 @@ function Base.show(io::IO, p::Plot)
     bc = BORDER_COLOR[]
 
     # plot all rows
-    for row in 1:nrows(c)
+    for row in 1:nr
         # print left annotations
-        print(io, repeat(🗷, p.margin))
+        print_nc(io, repeat(🗷, p.margin))
         if p.labels
             # Current labels to left and right of the row and their length
             left_str  = get(p.labels_left, row, "")
@@ -756,34 +780,36 @@ function Base.show(io::IO, p::Plot)
             end
             if !p.compact && row == y_lab_row
                 # print ylabel
-                print_color(io, :normal, p.ylabel)
-                print(io, repeat(🗷, max_len_l - length(p.ylabel) - left_len))
+                print_col(io, :normal, p.ylabel)
+                print_nc(io, repeat(🗷, max_len_l - length(p.ylabel) - left_len))
             else
                 # print padding to fill ylabel length
-                print(io, repeat(🗷, max_len_l - left_len))
+                print_nc(io, repeat(🗷, max_len_l - left_len))
             end
             # print the left annotation
-            print_color(io, left_col, left_str)
+            print_col(io, left_col, left_str)
         end
         if c.visible
             # print left border
-            print(io, plot_padding)
-            print_color(io, bc, bmap[:l])
+            print_nc(io, plot_padding)
+            print_col(io, bc, bmap[:l])
             # print canvas row
-            printrow(io, c, row)
+            printrow(io, print_nc, print_col, c, row)
             # print right label and padding
-            print_color(io, bc, bmap[:r])
+            print_col(io, bc, bmap[:r])
         end
         if p.labels
-            print(io, plot_padding)
-            print_color(io, right_col, right_str)
-            print(io, repeat(🗷, max_len_r - right_len))
+            print_nc(io, plot_padding)
+            print_col(io, right_col, right_str)
+            print_nc(io, repeat(🗷, max_len_r - right_len))
         end
         # print colorbar
         if p.colorbar
-            print(io, plot_padding)
-            printcolorbarrow(
+            print_nc(io, plot_padding)
+            print_colorbar_row(
                 io,
+                print_nc,
+                print_col,
                 c,
                 row,
                 callback,
@@ -796,54 +822,200 @@ function Base.show(io::IO, p::Plot)
                 🗷,
             )
         end
-        row < nrows(c) && println(io)
+        row < nrows(c) && print_nc(io, '\n')
     end
 
     # draw bottom border and bottom labels  
-    c.visible &&
-        print_border(io, :b, border_length, '\n' * border_left_pad, border_right_pad, bmap)
+    c.visible && print_border(
+        io,
+        print_nc,
+        print_col,
+        :b,
+        nc,
+        '\n' * border_left_pad,
+        border_right_pad,
+        bmap,
+    )
+    h_lbl = w_lbl = 0
     if p.labels
         print_labels(
             io,
+            print_nc,
+            print_col,
             :b,
             p,
-            border_length - 2,
+            nc - 2,
             '\n' * border_left_pad * 🗹,
             🗹 * border_right_pad,
             🗹,
         )
-        p.compact || print_title(
-            io,
-            '\n' * border_left_pad,
-            p.xlabel,
-            border_right_pad,
-            🗹;
-            p_width = p_width,
-        )
+        h_lbl += 1
+        if !p.compact
+            h_w = print_title(
+                io,
+                print_nc,
+                print_col,
+                '\n' * border_left_pad,
+                p.xlabel,
+                border_right_pad,
+                🗹;
+                p_width = p_width,
+            )
+            h_lbl += h_w[1]
+            w_lbl += h_w[2]
+        end
     end
-    nothing
+    # approximate image size
+    (
+        h_ttl + 1 + nr + 1 + h_lbl,  # +1: borders
+        max(w_ttl, w_lbl, length(border_left_pad) + p_width + length(border_right_pad)),
+    )
 end
 
+default_font(mono::Bool = false) =
+    if mono
+        if Sys.islinux()
+            "DejaVu Sans Mono"
+        elseif Sys.isbsd()
+            "Courier New"
+        elseif Sys.iswindows()
+            "Courier New"
+        else
+            @warn "unsupported $(Base.KERNEL)"
+            "Courier"
+        end
+    else
+        if Sys.islinux()
+            "DejaVu Sans"
+        elseif Sys.isbsd()
+            "Helvetica"
+        elseif Sys.iswindows()
+            "Arial"
+        else
+            @warn "unsupported $(Base.KERNEL)"
+            "Helvetica"
+        end
+    end
+
 """
-    savefig(p, filename; color=false)
+    savefig(p, filename; color = false, font = default_font(), pixelsize = 16)
 
-Print the given plot `p` to a text file.
+Save the given plot `p` to a `txt or `png` file.
 
-By default, it does not write ANSI color codes to the file. To enable this, set the keyword `color=true`.
+For text files, `savefig` does not write ANSI color codes to the file.
+To enable this, set the keyword `color=true`.
+
+For png files, `pixelsize` controls the image size scaling (defaults to `16`), and `font` the chosen font.
+To disable transparency use `transparent = false`.
 
 # Examples
 ```julia-repl
 julia> savefig(lineplot([0, 1]), "foo.txt")
-
+julia> savefig(lineplot([0, 1]), "foo.png"; font = "JuliaMono", pixelsize = 32)
 ```
 """
-function savefig(p::Plot, filename::String; color::Bool = false)
+function savefig(
+    p::Plot,
+    filename::String;
+    color::Bool = false,
+    font::AbstractString = default_font(),
+    pixelsize::Integer = 16,
+    transparent::Bool = false,
+    foreground::UserColorType = nothing,
+    background::UserColorType = nothing,
+)
     ext = lowercase(splitext(filename)[2])
-    if ext in (".png", ".jpg", ".jpeg", ".tif", ".gif", ".svg")
-        @warn "`UnicodePlots.savefig` only support writing to text files"
-    end
-    open(filename, "w") do io
-        print(IOContext(io, :color => color), p)
+    if ext in ("", ".txt")
+        open(filename, "w") do io
+            show(IOContext(io, :color => color), p)
+        end
+    elseif ext == ".png"
+        RGB24 = FreeTypeAbstraction.Colors.RGB24
+        RGBA = FreeTypeAbstraction.Colors.RGBA
+        RGB = FreeTypeAbstraction.Colors.RGB
+
+        fg_color = ansi_color(something(foreground, transparent ? :dark_gray : :light_gray))
+        bg_color = ansi_color(something(background, :black))
+
+        rgba(color::ColorType, alpha) = begin
+            color == INVALID_COLOR && (color = fg_color)
+            color < THRESHOLD || (color = LUT_8BIT[1 + (color - THRESHOLD)])
+            RGBA{Float32}(convert(RGB{Float32}, reinterpret(RGB24, color)), alpha)
+        end
+
+        default_fg_color = rgba(fg_color, 1.0)
+        default_bg_color = rgba(bg_color, transparent ? 0.0 : 1.0)
+
+        # compute final image size
+        noop = (args...) -> nothing
+        nr, nc = _show(devnull, noop, noop, p)
+
+        # hack printing to collect chars & colors
+        chars = sizehint!(Char[], nr * nc)
+        colors = sizehint!(RGBA{Float32}[], nr * nc)
+
+        print_nc(io, args...) = begin
+            line = string(args...)
+            append!(chars, line)
+            append!(colors, fill(default_fg_color, length(line)))
+        end
+
+        print_col(io, color, args...) = begin
+            color = rgba(ansi_color(color), 1.0)
+            line = string(args...)
+            append!(chars, line)
+            append!(colors, fill(color, length(line)))
+        end
+
+        # compute 1D stream of chars and colors
+        _show(IOContext(devnull, :color => true), print_nc, print_col, p)
+
+        # compute 2D grid (image) of chars and colors
+        lchrs = sizehint!([Char[]], nr)
+        lcols = sizehint!([RGBA{Float32}[]], nr)
+        r = 1
+        for (chr, col) in zip(chars, colors)
+            if chr == '\n'
+                r += 1
+                push!(lchrs, Char[])
+                push!(lcols, RGBA{Float32}[])
+                continue
+            end
+            push!(lchrs[r], chr)
+            push!(lcols[r], col)
+        end
+
+        # render image
+        face = FreeTypeAbstraction.findfont(font)
+
+        kr = ASPECT_RATIO
+        kc = kr / 2
+
+        img = fill(
+            default_bg_color,
+            ceil(Int, (kr * pixelsize) * nr),
+            ceil(Int, (kc * pixelsize) * nc),
+        )
+
+        y0 = round(Int, kr * pixelsize)
+        for (r, (chrs, cols)) in enumerate(zip(lchrs, lcols))
+            y = round(Int, y0 + (kr * pixelsize) * (r - 1))
+            FreeTypeAbstraction.renderstring!(
+                img,
+                String(chrs),
+                face,
+                pixelsize,
+                y,
+                0;
+                fcolor = cols,
+                bcolor = transparent ? nothing : default_bg_color,
+                valign = :vbaseline,
+                halign = :hleft,
+            )
+        end
+        FileIO.save(filename, img)
+    else
+        error("`savefig` only supports writing to `txt` or `png` files")
     end
     nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using StableRNGs
 using StatsBase
 using Crayons
 using Unitful
+import FileIO
 
 include("fixes.jl")
 

--- a/test/tst_deprecated_warns.jl
+++ b/test/tst_deprecated_warns.jl
@@ -33,7 +33,7 @@ end
         @test_logs (:warn, r"`annotate!`.+renamed") annotate!(p, :l, i, "$i", :yellow)
     end
 
-    @test_logs (:warn, r"`UnicodePlots.savefig`.+text") savefig(p, tempname() * ".png")
+    @test_throws ErrorException savefig(p, tempname() * ".jpg")
 end
 
 @testset "spy" begin

--- a/test/tst_plot.jl
+++ b/test/tst_plot.jl
@@ -158,3 +158,9 @@ end
     p = Plot([0, 1], [0, 1], yticks = false)
     test_ref("plot/no_yticks.txt", @show_col(p))
 end
+
+@testset "save as png" begin
+    p = lineplot([cos, sin, x -> 0.5, x -> -0.5], -π / 2, 2π)
+    tmp = tempname() * ".png"
+    savefig(p, tmp)
+end

--- a/test/tst_plot.jl
+++ b/test/tst_plot.jl
@@ -164,7 +164,11 @@ end
 
     for tr in (true, false)
         tmp = tempname() * ".png"
+
         savefig(p, tmp; transparent = tr)
         @test filesize(tmp) > 10_000
+
+        img = FileIO.load(tmp)
+        @test all(size(img) .> (400, 600))
     end
 end

--- a/test/tst_plot.jl
+++ b/test/tst_plot.jl
@@ -161,6 +161,10 @@ end
 
 @testset "save as png" begin
     p = lineplot([cos, sin, x -> 0.5, x -> -0.5], -π / 2, 2π)
-    tmp = tempname() * ".png"
-    savefig(p, tmp)
+
+    for tr in (true, false)
+        tmp = tempname() * ".png"
+        savefig(p, tmp; transparent = tr)
+        @test filesize(tmp) > 10_000
+    end
 end


### PR DESCRIPTION
Allow saving plot as `png` file using `FreeTypeAbstraction`.

Needs https://github.com/JuliaPlots/UnicodePlots.jl/pull/238 (true colors, `RGB`).
Needs https://github.com/JuliaGraphics/FreeTypeAbstraction.jl/pull/69.

**transparent**
![foo_tr](https://user-images.githubusercontent.com/13423344/159509562-51dbabe6-1fdd-494f-b833-876183feb4ca.png)

**non-transparent**
![foo](https://user-images.githubusercontent.com/13423344/159509500-5e8b0650-cfb2-4b80-9433-f7813efe2047.png)

