### PR TITLE
force auto formatting for vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+
 *.jl.cov
 *.jl.mem
 *.mem

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "[julia]": {
+        "editor.formatOnSave": true
+    }
+}


### PR DESCRIPTION
I didn't open the Julia auto formatter for my vscode because many old projects use random formats. But it's a good idea to provide a workspace-specific configuration so that everyone who devves UnicodePlots gets format on.

I also add `.vscode` into gitignore, so every changes to `.vscode` needs a force git add, e.g., `git add .vscode/settings.json -f`