### PR TITLE
eagerly load FileIO

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "b8865327-cd53-5732-bb35-84acbb429228"
 license = "MIT"
 desc = "Unicode-based scientific plotting for working in the terminal"
 authors = ["Christof Stocker <stocker.christof@gmail.com>", "T Bltg <tf.bltg@gmail.com>"]
-version = "2.12.0"
+version = "2.12.1"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"

--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -17,7 +17,7 @@ import Contour
 
 @lazy import FreeTypeAbstraction = "663a7486-cb36-511b-a19d-713bb74d65c9"
 import ColorTypes
-@lazy import FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+import FileIO
 
 export GraphicsArea,
     Canvas,


### PR DESCRIPTION
Unlike the filename version, the stream version has to manually create `DataFormat`; here FileIO is no longer a black-box and thus introduces world-age issues.
Let's roll back to still eagerly load it.

Since this is a bug fix, I'll merge and tag a release once the test passes.