### PR TITLE
Fix `width` - `height` order - style consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ The `projection` type for `MVP` can be set to either `:perspective` or `:orthogr
 
 Displaying the `x`, `y`, and `z` axes can be controlled using the `axes3d` keyword.
 
-For enhanced resolution, use a wider and/or taller `Plot` (this can be achieved using the unexported `UnicodePlots.default_size!(width=60)` for all future plots). </details>
+For enhanced resolution, use a wider and/or taller `Plot` (this can be achieved using `default_size!(width=60)` for all future plots). </details>
 
 <details>   <summary><a name=layout></a><b>Layout</b></summary>
 

--- a/docs/generate_docs.jl
+++ b/docs/generate_docs.jl
@@ -130,7 +130,7 @@ main() = begin
 
   indent(x, n) = repeat(tab, n) * join(split(x, '\n'), '\n' * repeat(tab, n))
   desc_ex(k, d, n=2) = (
-    if k == :border
+    if k ≡ :border
       join((
         d,
         indent(examples.border_dashed, n),
@@ -482,7 +482,7 @@ Here is a list of the main high-level functions for common scenarios:
 
   Displaying the `x`, `y`, and `z` axes can be controlled using the `axes3d` keyword.
 
-  For enhanced resolution, use a wider and/or taller `Plot` (this can be achieved using the unexported `UnicodePlots.default_size!(width=60)` for all future plots).
+  For enhanced resolution, use a wider and/or taller `Plot` (this can be achieved using `default_size!(width=60)` for all future plots).
 </details>
 
 <details>

--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -81,7 +81,8 @@ export GraphicsArea,
     polarplot,
     polarplot!,
     MVP,
-    savefig
+    savefig,
+    default_size!
 
 include("common.jl")
 include("lut.jl")

--- a/src/canvas.jl
+++ b/src/canvas.jl
@@ -84,7 +84,7 @@ function lines!(
     px, Px = min(px, Px), max(px, Px)
     py, Py = min(py, Py), max(py, Py)
 
-    if c_or_v1 isa AbstractFloat && c_or_v2 isa AbstractFloat && col_cb !== nothing
+    if c_or_v1 isa AbstractFloat && c_or_v2 isa AbstractFloat && col_cb ≢ nothing
         pixel!(c, floor(Int, cur_x), floor(Int, cur_y), col_cb(c_or_v1))
         start_x, start_y = cur_x, cur_y
         iΔ = 1 / √(Δx^2 + Δy^2)
@@ -168,8 +168,7 @@ function get_canvas_dimensions_for_matrix(
     height_diff = extra_rows
     width_diff  = margin + padding + length(string(ncol)) + extra_cols
 
-    term_height, term_width =
-        out_stream === nothing ? displaysize() : displaysize(out_stream)
+    term_height, term_width = out_stream_size(out_stream)
     max_height = max_height > 0 ? max_height : term_height - height_diff
     max_width = max_width > 0 ? max_width : term_width - width_diff
 
@@ -203,11 +202,11 @@ function get_canvas_dimensions_for_matrix(
         height = min(width / canv_ar, max_height)
     end
 
+    height = round(Int, height / (fix_ar ? ASPECT_RATIO[] : 1))  # optional terminal aspect ratio (4:3) correction
     width  = round(Int, width)
-    height = round(Int, height / (fix_ar ? ASPECT_RATIO : 1))  # optional terminal aspect ratio (4:3) correction
 
     # the canvas will target a (height, width) grid to represent the input data
-    width, height, max_width, max_height
+    height, width, max_height, max_width
 end
 
 function align_char_point(

--- a/src/canvas/asciicanvas.jl
+++ b/src/canvas/asciicanvas.jl
@@ -1,98 +1,98 @@
-const ascii_signs = [
+const ASCII_SIGNS = [
     0b100_000_000 0b000_100_000 0b000_000_100
     0b010_000_000 0b000_010_000 0b000_000_010
     0b001_000_000 0b000_001_000 0b000_000_001
 ]
 
-const ascii_lookup = Dict{UInt16,Char}()
-ascii_lookup[0b101_000_000] = '"'
-ascii_lookup[0b111_111_111] = '@'
-#ascii_lookup[0b011_110_011] = '$'
-ascii_lookup[0b010_000_000] = '\''
-ascii_lookup[0b010_100_010] = '('
-ascii_lookup[0b010_001_010] = ')'
-ascii_lookup[0b000_010_000] = '*'
-ascii_lookup[0b010_111_010] = '+'
-ascii_lookup[0b000_010_010] = ','
-ascii_lookup[0b000_100_100] = ','
-ascii_lookup[0b000_001_001] = ','
-ascii_lookup[0b000_111_000] = '-'
-ascii_lookup[0b000_000_010] = '.'
-ascii_lookup[0b000_000_100] = '.'
-ascii_lookup[0b000_000_001] = '.'
-ascii_lookup[0b001_010_100] = '/'
-ascii_lookup[0b010_100_000] = '/'
-ascii_lookup[0b001_010_110] = '/'
-ascii_lookup[0b011_010_010] = '/'
-ascii_lookup[0b001_010_010] = '/'
-ascii_lookup[0b110_010_111] = '1'
-#ascii_lookup[0b111_010_100] = '7'
-ascii_lookup[0b010_000_010] = ':'
-ascii_lookup[0b111_000_111] = '='
-#ascii_lookup[0b010_111_101] = 'A'
-#ascii_lookup[0b011_100_011] = 'C'
-#ascii_lookup[0b110_101_110] = 'D'
-#ascii_lookup[0b111_110_100] = 'F'
-#ascii_lookup[0b011_101_011] = 'G'
-#ascii_lookup[0b101_111_101] = 'H'
-ascii_lookup[0b111_010_111] = 'I'
-#ascii_lookup[0b011_001_111] = 'J'
-#ascii_lookup[0b101_110_101] = 'K'
-ascii_lookup[0b100_100_111] = 'L'
-#ascii_lookup[0b111_111_101] = 'M'
-#ascii_lookup[0b101_101_101] = 'N'
-#ascii_lookup[0b111_101_111] = 'O'
-#ascii_lookup[0b111_111_100] = 'P'
-ascii_lookup[0b111_010_010] = 'T'
-#ascii_lookup[0b101_101_111] = 'U'
-ascii_lookup[0b101_101_010] = 'V'
-#ascii_lookup[0b101_111_111] = 'W'
-ascii_lookup[0b101_010_101] = 'X'
-ascii_lookup[0b101_010_010] = 'Y'
-ascii_lookup[0b110_100_110] = '['
-ascii_lookup[0b010_001_000] = '\\'
-ascii_lookup[0b100_010_001] = '\\'
-ascii_lookup[0b110_010_010] = '\\'
-ascii_lookup[0b100_010_011] = '\\'
-ascii_lookup[0b100_010_010] = '\\'
-ascii_lookup[0b011_001_011] = ']'
-ascii_lookup[0b010_101_000] = '^'
-ascii_lookup[0b000_000_111] = '_'
-ascii_lookup[0b100_000_000] = '`'
-#ascii_lookup[0b000_111_111] = 'a'
-#ascii_lookup[0b100_111_111] = 'b'
-#ascii_lookup[0b001_111_111] = 'd'
-#ascii_lookup[0b001_111_010] = 'f'
-#ascii_lookup[0b100_111_101] = 'h'
-#ascii_lookup[0b100_101_101] = 'k'
-ascii_lookup[0b110_010_011] = 'l'
-#ascii_lookup[0b000_111_101] = 'n'
-ascii_lookup[0b000_111_100] = 'r'
-#ascii_lookup[0b000_101_111] = 'u'
-ascii_lookup[0b000_101_010] = 'v'
-ascii_lookup[0b011_110_011] = '{'
-ascii_lookup[0b010_010_010] = '|'
-ascii_lookup[0b100_100_100] = '|'
-ascii_lookup[0b001_001_001] = '|'
-ascii_lookup[0b110_011_110] = '}'
+const ASCII_LOOKUP = Dict{UInt16,Char}()
+ASCII_LOOKUP[0b101_000_000] = '"'
+ASCII_LOOKUP[0b111_111_111] = '@'
+# ASCII_LOOKUP[0b011_110_011] = '$'
+ASCII_LOOKUP[0b010_000_000] = '\''
+ASCII_LOOKUP[0b010_100_010] = '('
+ASCII_LOOKUP[0b010_001_010] = ')'
+ASCII_LOOKUP[0b000_010_000] = '*'
+ASCII_LOOKUP[0b010_111_010] = '+'
+ASCII_LOOKUP[0b000_010_010] = ','
+ASCII_LOOKUP[0b000_100_100] = ','
+ASCII_LOOKUP[0b000_001_001] = ','
+ASCII_LOOKUP[0b000_111_000] = '-'
+ASCII_LOOKUP[0b000_000_010] = '.'
+ASCII_LOOKUP[0b000_000_100] = '.'
+ASCII_LOOKUP[0b000_000_001] = '.'
+ASCII_LOOKUP[0b001_010_100] = '/'
+ASCII_LOOKUP[0b010_100_000] = '/'
+ASCII_LOOKUP[0b001_010_110] = '/'
+ASCII_LOOKUP[0b011_010_010] = '/'
+ASCII_LOOKUP[0b001_010_010] = '/'
+ASCII_LOOKUP[0b110_010_111] = '1'
+# ASCII_LOOKUP[0b111_010_100] = '7'
+ASCII_LOOKUP[0b010_000_010] = ':'
+ASCII_LOOKUP[0b111_000_111] = '='
+# ASCII_LOOKUP[0b010_111_101] = 'A'
+# ASCII_LOOKUP[0b011_100_011] = 'C'
+# ASCII_LOOKUP[0b110_101_110] = 'D'
+# ASCII_LOOKUP[0b111_110_100] = 'F'
+# ASCII_LOOKUP[0b011_101_011] = 'G'
+# ASCII_LOOKUP[0b101_111_101] = 'H'
+ASCII_LOOKUP[0b111_010_111] = 'I'
+# ASCII_LOOKUP[0b011_001_111] = 'J'
+# ASCII_LOOKUP[0b101_110_101] = 'K'
+ASCII_LOOKUP[0b100_100_111] = 'L'
+# ASCII_LOOKUP[0b111_111_101] = 'M'
+# ASCII_LOOKUP[0b101_101_101] = 'N'
+# ASCII_LOOKUP[0b111_101_111] = 'O'
+# ASCII_LOOKUP[0b111_111_100] = 'P'
+ASCII_LOOKUP[0b111_010_010] = 'T'
+# ASCII_LOOKUP[0b101_101_111] = 'U'
+ASCII_LOOKUP[0b101_101_010] = 'V'
+# ASCII_LOOKUP[0b101_111_111] = 'W'
+ASCII_LOOKUP[0b101_010_101] = 'X'
+ASCII_LOOKUP[0b101_010_010] = 'Y'
+ASCII_LOOKUP[0b110_100_110] = '['
+ASCII_LOOKUP[0b010_001_000] = '\\'
+ASCII_LOOKUP[0b100_010_001] = '\\'
+ASCII_LOOKUP[0b110_010_010] = '\\'
+ASCII_LOOKUP[0b100_010_011] = '\\'
+ASCII_LOOKUP[0b100_010_010] = '\\'
+ASCII_LOOKUP[0b011_001_011] = ']'
+ASCII_LOOKUP[0b010_101_000] = '^'
+ASCII_LOOKUP[0b000_000_111] = '_'
+ASCII_LOOKUP[0b100_000_000] = '`'
+# ASCII_LOOKUP[0b000_111_111] = 'a'
+# ASCII_LOOKUP[0b100_111_111] = 'b'
+# ASCII_LOOKUP[0b001_111_111] = 'd'
+# ASCII_LOOKUP[0b001_111_010] = 'f'
+# ASCII_LOOKUP[0b100_111_101] = 'h'
+# ASCII_LOOKUP[0b100_101_101] = 'k'
+ASCII_LOOKUP[0b110_010_011] = 'l'
+# ASCII_LOOKUP[0b000_111_101] = 'n'
+ASCII_LOOKUP[0b000_111_100] = 'r'
+# ASCII_LOOKUP[0b000_101_111] = 'u'
+ASCII_LOOKUP[0b000_101_010] = 'v'
+ASCII_LOOKUP[0b011_110_011] = '{'
+ASCII_LOOKUP[0b010_010_010] = '|'
+ASCII_LOOKUP[0b100_100_100] = '|'
+ASCII_LOOKUP[0b001_001_001] = '|'
+ASCII_LOOKUP[0b110_011_110] = '}'
 
-const n_ascii = 512
-const ascii_decode = Vector{Char}(undef, typemax(UInt16))
-ascii_decode[1] = ' '
-for i in 2:n_ascii
+const N_ASCII = 512
+const ASCII_DECODE = Vector{Char}(undef, typemax(UInt16))
+ASCII_DECODE[1] = ' '
+for i in 2:N_ASCII
     min_dist = typemax(Int)
     min_char = ' '
-    for (k, v) in sort_by_keys(ascii_lookup)
+    for (k, v) in sort_by_keys(ASCII_LOOKUP)
         cur_dist = count_ones(xor(UInt16(i - 1), k))
         if cur_dist < min_dist
             min_dist = cur_dist
             min_char = v
         end
     end
-    ascii_decode[i] = min_char
+    ASCII_DECODE[i] = min_char
 end
 
-ascii_decode[(n_ascii + 1):typemax(UInt16)] = unicode_table[1:(typemax(UInt16) - n_ascii)]
+ASCII_DECODE[(N_ASCII + 1):typemax(UInt16)] = UNICODE_TABLE[1:(typemax(UInt16) - N_ASCII)]
 
 """
 As the name suggests the `AsciiCanvas` only uses
@@ -126,8 +126,8 @@ end
 @inline x_pixel_per_char(::Type{C}) where {C<:AsciiCanvas} = 3
 @inline y_pixel_per_char(::Type{C}) where {C<:AsciiCanvas} = 3
 
-@inline lookup_encode(::AsciiCanvas) = ascii_signs
-@inline lookup_decode(::AsciiCanvas) = ascii_decode
+@inline lookup_encode(::AsciiCanvas) = ASCII_SIGNS
+@inline lookup_decode(::AsciiCanvas) = ASCII_DECODE
 
 AsciiCanvas(args...; kw...) =
     CreateLookupCanvas(AsciiCanvas, UInt16, (0b000_000_000, 0b111_111_111), args...; kw...)
@@ -140,7 +140,7 @@ function char_point!(
     color::UserColorType,
 )
     if checkbounds(Bool, c.grid, char_x, char_y)
-        c.grid[char_x, char_y] = n_ascii + char
+        c.grid[char_x, char_y] = N_ASCII + char
         set_color!(c.colors, char_x, char_y, ansi_color(color), c.blend)
     end
     c

--- a/src/canvas/blockcanvas.jl
+++ b/src/canvas/blockcanvas.jl
@@ -1,27 +1,27 @@
-const block_signs = [
+const BLOCK_SIGNS = [
     0b1000 0b0010
     0b0100 0b0001
 ]
 
-const n_block = 16
-const block_decode = Vector{Char}(undef, typemax(UInt16))
-block_decode[1] = ' '
-block_decode[2] = '▗'
-block_decode[3] = '▖'
-block_decode[4] = '▄'
-block_decode[5] = '▝'
-block_decode[6] = '▐'
-block_decode[7] = '▞'
-block_decode[8] = '▟'
-block_decode[9] = '▘'
-block_decode[10] = '▚'
-block_decode[11] = '▌'
-block_decode[12] = '▙'
-block_decode[13] = '▀'
-block_decode[14] = '▜'
-block_decode[15] = '▛'
-block_decode[16] = '█'
-block_decode[(n_block + 1):typemax(UInt16)] = unicode_table[1:(typemax(UInt16) - n_block)]
+const N_BLOCK = 16
+const BLOCK_DECODE = Vector{Char}(undef, typemax(UInt16))
+BLOCK_DECODE[1] = ' '
+BLOCK_DECODE[2] = '▗'
+BLOCK_DECODE[3] = '▖'
+BLOCK_DECODE[4] = '▄'
+BLOCK_DECODE[5] = '▝'
+BLOCK_DECODE[6] = '▐'
+BLOCK_DECODE[7] = '▞'
+BLOCK_DECODE[8] = '▟'
+BLOCK_DECODE[9] = '▘'
+BLOCK_DECODE[10] = '▚'
+BLOCK_DECODE[11] = '▌'
+BLOCK_DECODE[12] = '▙'
+BLOCK_DECODE[13] = '▀'
+BLOCK_DECODE[14] = '▜'
+BLOCK_DECODE[15] = '▛'
+BLOCK_DECODE[16] = '█'
+BLOCK_DECODE[(N_BLOCK + 1):typemax(UInt16)] = UNICODE_TABLE[1:(typemax(UInt16) - N_BLOCK)]
 
 """
 The `BlockCanvas` is also Unicode-based.
@@ -51,8 +51,8 @@ end
 @inline x_pixel_per_char(::Type{C}) where {C<:BlockCanvas} = 2
 @inline y_pixel_per_char(::Type{C}) where {C<:BlockCanvas} = 2
 
-@inline lookup_encode(::BlockCanvas) = block_signs
-@inline lookup_decode(::BlockCanvas) = block_decode
+@inline lookup_encode(::BlockCanvas) = BLOCK_SIGNS
+@inline lookup_decode(::BlockCanvas) = BLOCK_DECODE
 
 BlockCanvas(args...; kw...) =
     CreateLookupCanvas(BlockCanvas, UInt16, (0b0000, 0b1111), args...; kw...)
@@ -65,7 +65,7 @@ function char_point!(
     color::UserColorType,
 )
     if checkbounds(Bool, c.grid, char_x, char_y)
-        c.grid[char_x, char_y] = n_block + char
+        c.grid[char_x, char_y] = N_BLOCK + char
         set_color!(c.colors, char_x, char_y, ansi_color(color), c.blend)
     end
     c

--- a/src/canvas/braillecanvas.jl
+++ b/src/canvas/braillecanvas.jl
@@ -93,7 +93,7 @@ function pixel!(c::BrailleCanvas, pixel_x::Int, pixel_y::Int, color::UserColorTy
     0 ≤ pixel_x ≤ c.pixel_width || return c
     0 ≤ pixel_y ≤ c.pixel_height || return c
     char_x, char_y, char_x_off, char_y_off = pixel_to_char_point(c, pixel_x, pixel_y)
-    if BLANK_BRAILLE <= (val = UInt64(c.grid[char_x, char_y])) <= FULL_BRAILLE
+    if BLANK_BRAILLE ≤ (val = UInt64(c.grid[char_x, char_y])) ≤ FULL_BRAILLE
         c.grid[char_x, char_y] = Char(val | UInt64(braille_signs[char_x_off, char_y_off]))
     end
     set_color!(c.colors, char_x, char_y, ansi_color(color), c.blend)
@@ -115,7 +115,7 @@ function char_point!(
 end
 
 function printrow(io::IO, print_nc, print_col, c::BrailleCanvas, row::Int)
-    0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    0 < row ≤ nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     y = row
     for x in 1:ncols(c)
         print_col(io, c.colors[x, y], c.grid[x, y])

--- a/src/canvas/braillecanvas.jl
+++ b/src/canvas/braillecanvas.jl
@@ -81,9 +81,6 @@ function pixel_to_char_point(c::BrailleCanvas, pixel_x::Number, pixel_y::Number)
     tmp = pixel_x / c.pixel_width * cw
     char_x = floor(Int, tmp) + 1
     char_x_off = (pixel_x % 2) + 1
-    if char_x < round(Int, tmp, RoundNearestTiesUp) + 1 && char_x_off == 1
-        char_x += 1
-    end
     char_y = floor(Int, pixel_y / c.pixel_height * ch) + 1
     char_y_off = (pixel_y % 4) + 1
     char_x, char_y, char_x_off, char_y_off

--- a/src/canvas/braillecanvas.jl
+++ b/src/canvas/braillecanvas.jl
@@ -1,4 +1,4 @@
-const braille_signs = [
+const BRAILLE_SIGNS = [
     '⠁' '⠂' '⠄' '⡀'
     '⠈' '⠐' '⠠' '⢀'
 ]
@@ -91,7 +91,7 @@ function pixel!(c::BrailleCanvas, pixel_x::Int, pixel_y::Int, color::UserColorTy
     0 ≤ pixel_y ≤ c.pixel_height || return c
     char_x, char_y, char_x_off, char_y_off = pixel_to_char_point(c, pixel_x, pixel_y)
     if BLANK_BRAILLE ≤ (val = UInt64(c.grid[char_x, char_y])) ≤ FULL_BRAILLE
-        c.grid[char_x, char_y] = Char(val | UInt64(braille_signs[char_x_off, char_y_off]))
+        c.grid[char_x, char_y] = Char(val | UInt64(BRAILLE_SIGNS[char_x_off, char_y_off]))
     end
     set_color!(c.colors, char_x, char_y, ansi_color(color), c.blend)
     c

--- a/src/canvas/densitycanvas.jl
+++ b/src/canvas/densitycanvas.jl
@@ -84,8 +84,8 @@ function pixel_to_char_point(c::DensityCanvas, pixel_x::Number, pixel_y::Number)
 end
 
 function pixel!(c::DensityCanvas, pixel_x::Int, pixel_y::Int, color::UserColorType)
-    0 <= pixel_x <= c.pixel_width || return c
-    0 <= pixel_y <= c.pixel_height || return c
+    0 ≤ pixel_x ≤ c.pixel_width || return c
+    0 ≤ pixel_y ≤ c.pixel_height || return c
     char_x, char_y = pixel_to_char_point(c, pixel_x, pixel_y)
     c.grid[char_x, char_y] += 1
     c.max_density = max(c.max_density, c.grid[char_x, char_y])
@@ -94,7 +94,7 @@ function pixel!(c::DensityCanvas, pixel_x::Int, pixel_y::Int, color::UserColorTy
 end
 
 function printrow(io::IO, print_nc, print_col, c::DensityCanvas, row::Int)
-    0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    0 < row ≤ nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     signs = den_signs[]
     y = row
     den_sign_count = length(signs)

--- a/src/canvas/densitycanvas.jl
+++ b/src/canvas/densitycanvas.jl
@@ -1,4 +1,4 @@
-const den_signs = Ref([' ', '░', '▒', '▓', '█'])
+const DEN_SIGNS = Ref((' ', '░', '▒', '▓', '█'))
 
 """
 Unlike the `BrailleCanvas`, the density canvas
@@ -95,7 +95,7 @@ end
 
 function printrow(io::IO, print_nc, print_col, c::DensityCanvas, row::Int)
     0 < row ≤ nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
-    signs = den_signs[]
+    signs = DEN_SIGNS[]
     y = row
     den_sign_count = length(signs)
     val_scale = (den_sign_count - 1) / c.max_density

--- a/src/canvas/dotcanvas.jl
+++ b/src/canvas/dotcanvas.jl
@@ -1,12 +1,12 @@
-const dot_signs = [0b10 0b01]
+const DOT_SIGNS = [0b10 0b01]
 
-const n_dot = 4
-const dot_decode = Array{Char}(undef, typemax(UInt16))
-dot_decode[1] = ' '
-dot_decode[2] = '.'
-dot_decode[3] = '\''
-dot_decode[4] = ':'
-dot_decode[(n_dot + 1):typemax(UInt16)] = unicode_table[1:(typemax(UInt16) - n_dot)]
+const N_DOT = 4
+const DOT_DECODE = Array{Char}(undef, typemax(UInt16))
+DOT_DECODE[1] = ' '
+DOT_DECODE[2] = '.'
+DOT_DECODE[3] = '\''
+DOT_DECODE[4] = ':'
+DOT_DECODE[(N_DOT + 1):typemax(UInt16)] = UNICODE_TABLE[1:(typemax(UInt16) - N_DOT)]
 
 """
 Similar to the `AsciiCanvas`, the `DotCanvas` only uses
@@ -40,8 +40,8 @@ end
 @inline x_pixel_per_char(::Type{C}) where {C<:DotCanvas} = 1
 @inline y_pixel_per_char(::Type{C}) where {C<:DotCanvas} = 2
 
-@inline lookup_encode(::DotCanvas) = dot_signs
-@inline lookup_decode(::DotCanvas) = dot_decode
+@inline lookup_encode(::DotCanvas) = DOT_SIGNS
+@inline lookup_decode(::DotCanvas) = DOT_DECODE
 
 DotCanvas(args...; kw...) =
     CreateLookupCanvas(DotCanvas, UInt16, (0b00, 0b11), args...; kw...)
@@ -54,7 +54,7 @@ function char_point!(
     color::UserColorType,
 )
     if checkbounds(Bool, c.grid, char_x, char_y)
-        c.grid[char_x, char_y] = n_dot + char
+        c.grid[char_x, char_y] = N_DOT + char
         set_color!(c.colors, char_x, char_y, ansi_color(color), c.blend)
     end
     c

--- a/src/canvas/heatmapcanvas.jl
+++ b/src/canvas/heatmapcanvas.jl
@@ -43,7 +43,7 @@ function HeatmapCanvas(args...; kw...)
 end
 
 function printrow(io::IO, print_nc, print_col, c::HeatmapCanvas, row::Int)
-    0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    0 < row ≤ nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     y = 2row
 
     # extend the plot upwards by half a row

--- a/src/canvas/lookupcanvas.jl
+++ b/src/canvas/lookupcanvas.jl
@@ -1,19 +1,19 @@
 # en.wikipedia.org/wiki/Plane_(Unicode)
-const plane0_start = 0x00000
-const plane0_stop = 0x0FFFF
-const plane1_start = 0x10000
-const plane1_stop = 0x1FFFF
-const plane2_start = 0x20000
-const plane2_stop = 0x2FFFF
+const PLANE0_START = 0x00000
+const PLANE0_STOP = 0x0FFFF
+const PLANE1_START = 0x10000
+const PLANE1_STOP = 0x1FFFF
+const PLANE2_START = 0x20000
+const PLANE2_STOP = 0x2FFFF
 
 # TODO: maybe later support plane 1 (SMP) and plane 2 (CJK) (needs UInt16 -> UInt32 grid change)
-const unicode_table = Array{Char}(undef, (plane0_stop - plane0_start + 1) + length(MARKERS))
-for i in plane0_start:plane0_stop
-    unicode_table[i + 1] = Char(i)
+const UNICODE_TABLE = Array{Char}(undef, (PLANE0_STOP - PLANE0_START + 1) + length(MARKERS))
+for i in PLANE0_START:PLANE0_STOP
+    UNICODE_TABLE[i + 1] = Char(i)
 end
 
-for (j, i) in enumerate(plane1_start:(plane1_start + (length(MARKERS) - 1)))
-    unicode_table[i + 1] = MARKERS[j]
+for (j, i) in enumerate(PLANE1_START:(PLANE1_START + (length(MARKERS) - 1)))
+    UNICODE_TABLE[i + 1] = MARKERS[j]
 end
 
 abstract type LookupCanvas <: Canvas end

--- a/src/canvas/lookupcanvas.jl
+++ b/src/canvas/lookupcanvas.jl
@@ -95,10 +95,10 @@ function pixel!(
     pixel_y::Int,
     color::UserColorType,
 ) where {T<:LookupCanvas}
-    0 <= pixel_x <= pixel_width(c) || return c
-    0 <= pixel_y <= pixel_height(c) || return c
+    0 ≤ pixel_x ≤ pixel_width(c) || return c
+    0 ≤ pixel_y ≤ pixel_height(c) || return c
     char_x, char_y, char_x_off, char_y_off = pixel_to_char_point(c, pixel_x, pixel_y)
-    if (val = UInt64(grid(c)[char_x, char_y])) == 0 || c.min_max[1] <= val <= c.min_max[2]
+    if (val = UInt64(grid(c)[char_x, char_y])) == 0 || c.min_max[1] ≤ val ≤ c.min_max[2]
         grid(c)[char_x, char_y] |= lookup_encode(c)[char_x_off, char_y_off]
     end
     blend = color isa Symbol && c.blend  # don't attempt to blend colors if they have been explicitly specified
@@ -107,7 +107,7 @@ function pixel!(
 end
 
 function printrow(io::IO, print_nc, print_col, c::LookupCanvas, row::Int)
-    0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    0 < row ≤ nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     y = row
     for x in 1:ncols(c)
         print_col(io, colors(c)[x, y], lookup_decode(c)[grid(c)[x, y] + 1])

--- a/src/colormaps.jl
+++ b/src/colormaps.jl
@@ -14,7 +14,7 @@
 # You should have received a copy of the CC0 legalcode along with this
 # work.  If not, see <creativecommons.org/publicdomain/zero/1.0/>.
 
-const _magma_data = [
+const MAGMA_DATA = [
     (0.001462, 0.000466, 0.013866),
     (0.002258, 0.001295, 0.018331),
     (0.003279, 0.002305, 0.023708),
@@ -273,7 +273,7 @@ const _magma_data = [
     (0.987053, 0.991438, 0.749504),
 ]
 
-const _inferno_data = [
+const INFERNO_DATA = [
     (0.001462, 0.000466, 0.013866),
     (0.002267, 0.001270, 0.018570),
     (0.003299, 0.002249, 0.024239),
@@ -532,7 +532,7 @@ const _inferno_data = [
     (0.988362, 0.998364, 0.644924),
 ]
 
-const _plasma_data = [
+const PLASMA_DATA = [
     (0.050383, 0.029803, 0.527975),
     (0.063536, 0.028426, 0.533124),
     (0.075353, 0.027206, 0.538007),
@@ -791,7 +791,7 @@ const _plasma_data = [
     (0.940015, 0.975158, 0.131326),
 ]
 
-const _viridis_data = [
+const VIRIDIS_DATA = [
     (0.267004, 0.004874, 0.329415),
     (0.268510, 0.009605, 0.335427),
     (0.269944, 0.014625, 0.341379),
@@ -1050,7 +1050,7 @@ const _viridis_data = [
     (0.993248, 0.906157, 0.143936),
 ]
 
-const _cividis_data = [
+const CIVIDIS_DATA = [
     (0.000000, 0.135112, 0.304751),
     (0.000000, 0.138068, 0.311105),
     (0.000000, 0.141013, 0.317579),
@@ -1310,7 +1310,7 @@ const _cividis_data = [
 ]
 
 # inspired from metacpan.org/pod/Term::Colormap
-const _jet_data = [
+const JET_DATA = [
     (0.0, 0.0, 1.0),
     (0.0, 0.372549, 1.0),
     (0.0, 0.529412, 1.0),
@@ -1338,7 +1338,7 @@ const _jet_data = [
     (0.803922, 0.0, 0.0),
 ]
 
-const _snow_data = [
+const SNOW_DATA = [
     (0.933333, 0.933333, 0.933333),
     (0.894118, 0.894118, 0.894118),
     (0.854902, 0.854902, 0.854902),
@@ -1353,7 +1353,7 @@ const _snow_data = [
     (0.501961, 0.501961, 0.501961),
 ]
 
-const _ash_data = [
+const ASH_DATA = [
     (0.462745, 0.462745, 0.462745),
     (0.423529, 0.423529, 0.423529),
     (0.384314, 0.384314, 0.384314),
@@ -1368,9 +1368,9 @@ const _ash_data = [
     (0.031373, 0.031373, 0.031373),
 ]
 
-const _gray_data = hcat(_snow_data, _ash_data)
+const GRAY_DATA = hcat(SNOW_DATA, ASH_DATA)
 
-const _green_cyan_blue_data = [
+const GREEN_CYAN_BLUE_DATA = [
     (0.0, 0.372549, 0.0),
     (0.0, 0.529412, 0.0),
     (0.0, 0.686275, 0.0),
@@ -1392,17 +1392,17 @@ const _green_cyan_blue_data = [
     (0.0, 0.0, 0.372549),
 ]
 
-const COLOR_MAP_DATA = Dict(
-    :viridis => _viridis_data,
-    :inferno => _inferno_data,
-    :magma => _magma_data,
-    :plasma => _plasma_data,
-    :cividis => _cividis_data,
-    :green_cyan_blue => _green_cyan_blue_data,
-    :gray => _gray_data,
-    :snow => _snow_data,
-    :ash => _ash_data,
-    :jet => _jet_data,
+const COLOR_MAP_DATA = (
+    viridis = VIRIDIS_DATA,
+    inferno = INFERNO_DATA,
+    magma = MAGMA_DATA,
+    plasma = PLASMA_DATA,
+    cividis = CIVIDIS_DATA,
+    green_cyan_blue = GREEN_CYAN_BLUE_DATA,
+    gray = GRAY_DATA,
+    snow = SNOW_DATA,
+    ash = ASH_DATA,
+    jet = JET_DATA,
 )
 
 c256(c::AbstractFloat) = round(Int, 255c)

--- a/src/common.jl
+++ b/src/common.jl
@@ -158,11 +158,11 @@ const BORDER_COLOR = Ref(:dark_gray)
 # standard terminals seem to respect a 4:3 aspect ratio
 # unix.stackexchange.com/questions/148569/standard-terminal-font-aspect-ratio
 # retrocomputing.stackexchange.com/questions/5629/why-did-80x25-become-the-text-monitor-standard
-const ASPECT_RATIO = 4 / 3
+const ASPECT_RATIO = Ref(4 / 3)
 
 # default display size for the default BrailleCanvas (which has aspect ratio = 2) ==> (40, 15)
 const DEFAULT_HEIGHT = Ref(15)
-const DEFAULT_WIDTH = Ref(round(Int, DEFAULT_HEIGHT[] * 2ASPECT_RATIO))
+const DEFAULT_WIDTH = Ref(round(Int, DEFAULT_HEIGHT[] * 2ASPECT_RATIO[]))
 
 const MarkerType = Union{Symbol,Char,AbstractString}
 const CrayonColorType = Union{Integer,Symbol,NTuple{3,Integer},Nothing}
@@ -229,20 +229,20 @@ function __init__()
 end
 
 function default_size!(;
-    width::Union{Integer,Nothing} = nothing,
     height::Union{Integer,Nothing} = nothing,
+    width::Union{Integer,Nothing} = nothing,
 )
-    @assert width === nothing || height === nothing
-    if width !== nothing
-        DEFAULT_WIDTH[] = width
-        DEFAULT_HEIGHT[] = round(Int, width / 2ASPECT_RATIO)
-    elseif height !== nothing
+    @assert height ≡ nothing || width ≡ nothing
+    if height ≢ nothing
         DEFAULT_HEIGHT[] = height
-        DEFAULT_WIDTH[] = round(Int, height * 2ASPECT_RATIO)
+        DEFAULT_WIDTH[] = round(Int, height * 2ASPECT_RATIO[])
+    elseif width ≢ nothing
+        DEFAULT_WIDTH[] = width
+        DEFAULT_HEIGHT[] = round(Int, width / 2ASPECT_RATIO[])
     else
         default_size!(height = 15)
     end
-    nothing
+    DEFAULT_HEIGHT[], DEFAULT_WIDTH[]  # `displaysize` order convention
 end
 
 function char_marker(marker::MarkerType)::Char
@@ -251,7 +251,7 @@ function char_marker(marker::MarkerType)::Char
     else
         length(marker) == 1 ||
             throw(ArgumentError("`marker` keyword has a non unit length"))
-        marker[1]
+        first(marker)
     end
 end
 
@@ -267,7 +267,7 @@ end
 
 as_float(x) = eltype(x) <: AbstractFloat ? x : float.(x)
 
-roundable(num::Number) = isinteger(num) & (typemin(Int) <= num < typemax(Int))
+roundable(num::Number) = isinteger(num) & (typemin(Int) ≤ num < typemax(Int))
 compact_repr(num::Number) = repr(num, context = :compact => true)
 
 ceil_neg_log10(x) =
@@ -373,7 +373,7 @@ function extend_limits(vec, limits, scale::Union{Symbol,Function})
     end
 end
 
-sort_by_keys(dict::Dict) = sort!(collect(dict), by = x -> x[1])
+sort_by_keys(dict::Dict) = sort!(collect(dict), by = x -> first(x))
 
 function sorted_keys_values(dict::Dict; k2s = true)
     if k2s  # check and force key type to be of AbstractString type if necessary
@@ -450,7 +450,7 @@ end
         INVALID_COLOR
     end
 
-ignored_color(color::Symbol) = color === :normal || color === :default || color === :nothing
+ignored_color(color::Symbol) = color ≡ :normal || color ≡ :default || color ≡ :nothing
 ignored_color(::Nothing) = true
 ignored_color(::Any) = false
 
@@ -514,13 +514,15 @@ complement(color::ColorType)::ColorType =
     nothing
 end
 
-out_stream_size(out_stream::Union{Nothing,IO}) =
-    out_stream === nothing ? (DEFAULT_WIDTH[], DEFAULT_HEIGHT[]) : displaysize(out_stream)
-out_stream_width(out_stream::Union{Nothing,IO})::Int = out_stream_size(out_stream)[1]
-out_stream_height(out_stream::Union{Nothing,IO})::Int = out_stream_size(out_stream)[2]
+out_stream_size(out_stream::Union{Nothing,IO} = nothing) =
+    out_stream ≡ nothing ? displaysize() : displaysize(out_stream)
+out_stream_height(out_stream::Union{Nothing,IO} = nothing) =
+    first(out_stream_size(out_stream))
+out_stream_width(out_stream::Union{Nothing,IO} = nothing) =
+    last(out_stream_size(out_stream))
 
 function _handle_deprecated_symb(symb, symbols)
-    if symb === nothing
+    if symb ≡ nothing
         symbols
     else
         Base.depwarn(

--- a/src/common.jl
+++ b/src/common.jl
@@ -228,6 +228,14 @@ function __init__()
     nothing
 end
 
+"""
+    default_size!(;
+        height::Union{Integer,Nothing} = nothing,
+        width::Union{Integer,Nothing} = nothing,
+    )
+
+# Change and return the default plot size (height, width).
+"""
 function default_size!(;
     height::Union{Integer,Nothing} = nothing,
     width::Union{Integer,Nothing} = nothing,
@@ -517,9 +525,9 @@ end
 out_stream_size(out_stream::Union{Nothing,IO} = nothing) =
     out_stream ≡ nothing ? displaysize() : displaysize(out_stream)
 out_stream_height(out_stream::Union{Nothing,IO} = nothing) =
-    first(out_stream_size(out_stream))
+    out_stream |> out_stream_size |> first
 out_stream_width(out_stream::Union{Nothing,IO} = nothing) =
-    last(out_stream_size(out_stream))
+    out_stream |> out_stream_size |> last
 
 function _handle_deprecated_symb(symb, symbols)
     if symb ≡ nothing

--- a/src/description.jl
+++ b/src/description.jl
@@ -180,8 +180,8 @@ function arguments(
 )
     get_description(n, d) = begin
         str = d[n]
-        @assert str[1] === '`' || islowercase(str[1])  # description starts with a lowercase string, or `something`
-        @assert str[end] !== '.'  # trailing dot will be added later
+        @assert first(str) ≡ '`' || islowercase(first(str))  # description starts with a lowercase string, or `something`
+        @assert last(str) ≢ '.'  # trailing dot will be added later
         str
     end
     all_desc = (; DESCRIPTION..., desc...)  # desc preempts defaults !

--- a/src/graphics.jl
+++ b/src/graphics.jl
@@ -5,7 +5,7 @@ function ncols end
 function printrow end
 
 suitable_color(c::GraphicsArea, color::Union{UserColorType,AbstractVector}) = ansi_color(
-    color === nothing && length(c.colors) > 0 ? c.colors[end] :
+    color ≡ nothing && length(c.colors) > 0 ? c.colors[end] :
     (color isa AbstractVector ? first(color) : color),
 )
 

--- a/src/graphics/bargraphics.jl
+++ b/src/graphics/bargraphics.jl
@@ -93,7 +93,7 @@ end
 function printrow(io::IO, print_nc, print_col, c::BarplotGraphics, row::Int)
     0 < row ≤ nrows(c) || throw(ArgumentError("Argument \"row\" out of bounds: $row"))
     bar = c.bars[row]
-    max_val = c.maximum === nothing ? c.max_val : max(c.max_val, c.maximum)
+    max_val = c.maximum ≡ nothing ? c.max_val : max(c.max_val, c.maximum)
     max_bar_width = max(c.char_width - 2 - c.max_len, 1)
     val = c.xscale(bar)
     nsyms = length(c.symbols)

--- a/src/graphics/boxgraphics.jl
+++ b/src/graphics/boxgraphics.jl
@@ -87,7 +87,7 @@ function addseries!(
 end
 
 function printrow(io::IO, print_nc, print_col, c::BoxplotGraphics, row::Int)
-    0 < row <= nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
+    0 < row ≤ nrows(c) || throw(ArgumentError("Argument row out of bounds: $row"))
     idx = ceil(Int, row / 3)
     series = c.data[idx]
 

--- a/src/interface/barplot.jl
+++ b/src/interface/barplot.jl
@@ -58,8 +58,7 @@ function barplot(
     heights::AbstractVector{<:Number};
     border = :barplot,
     color::Union{UserColorType,AbstractVector} = :green,
-    out_stream::Union{Nothing,IO} = nothing,
-    width::Int = out_stream_width(out_stream),
+    width::Union{Nothing,Integer} = nothing,
     symb = nothing,  # deprecated
     symbols = KEYWORDS.symbols,
     xscale = KEYWORDS.xscale,
@@ -70,7 +69,7 @@ function barplot(
 )
     length(text) == length(heights) ||
         throw(DimensionMismatch("The given vectors must be of the same length"))
-    minimum(heights) >= 0 || throw(
+    minimum(heights) ≥ 0 || throw(
         ArgumentError("All values have to be positive. Negative bars are not supported."),
     )
 
@@ -81,7 +80,7 @@ function barplot(
             lines = split(t, '\n')
             if (n = length(lines)) > 1
                 append!(_text, lines)
-                for i in 1:n
+                for i in eachindex(lines)
                     push!(_heights, i == n ? h : -1)
                 end
             else
@@ -94,7 +93,7 @@ function barplot(
 
     area = BarplotGraphics(
         heights,
-        width,
+        something(width, DEFAULT_WIDTH[]),
         xscale;
         color = color,
         symbols = _handle_deprecated_symb(symb, symbols),

--- a/src/interface/boxplot.jl
+++ b/src/interface/boxplot.jl
@@ -6,15 +6,13 @@
 Draws a box-and-whisker plot.
 
 The first argument specifies the data to plot. This is a vector
-of vectors, with each inner vector representing a data series. We
-use a vector of vectors over a matrix to allow series of
-different lengths. Optionally, a list of text may be provided,
-with length equal to the number of series.
+of vectors, with each inner vector representing a data series.
+We use a vector of vectors over a matrix to allow series of different lengths.
+Optionally, a list of text may be provided, with length equal to the number of series.
 
-Alternatively, one can specify a boxplot using a dictionary. In
-that case, the values, which have to be numeric, will be used as
-the data series, and the keys, which have to be strings, will be
-used as the labels.
+Alternatively, one can specify a boxplot using a dictionary.
+In that case, the values, which have to be numeric, will be used as the data series,
+and the keys, which have to be strings, will be used as the labels.
 
 # Usage
     
@@ -59,8 +57,7 @@ function boxplot(
     data::AbstractVector{<:AbstractArray{<:Number}};
     border = :corners,
     color::Union{UserColorType,AbstractVector} = :green,
-    out_stream::Union{Nothing,IO} = nothing,
-    width::Int = out_stream_width(out_stream),
+    width::Union{Nothing,Integer} = nothing,
     xlim = KEYWORDS.xlim,
     kw...,
 )
@@ -68,9 +65,9 @@ function boxplot(
         throw(ArgumentError("xlim must be a tuple or a vector of length 2"))
     length(text) == length(data) || throw(DimensionMismatch("Wrong number of text"))
     min_x, max_x = extend_limits(reduce(vcat, data), xlim)
-    width = max(width, 10)
+    width = max(something(width, DEFAULT_WIDTH[]), 10)
 
-    area = BoxplotGraphics(data[1], width, color = color, min_x = min_x, max_x = max_x)
+    area = BoxplotGraphics(first(data), width, color = color, min_x = min_x, max_x = max_x)
     for i in 2:length(data)
         addseries!(area, data[i])
     end

--- a/src/interface/heatmap.jl
+++ b/src/interface/heatmap.jl
@@ -86,11 +86,11 @@ function heatmap(
     end
 
     # select a subset of A based on the supplied limits
-    firstx = findfirst(x -> x >= xlim[1], X)
-    lastx = findlast(x -> x <= xlim[2], X)
+    firstx = findfirst(x -> x ≥ xlim[1], X)
+    lastx = findlast(x -> x ≤ xlim[2], X)
     xrange = (firstx == nothing || lastx == nothing) ? (1:0) : (firstx:lastx)
-    firsty = findfirst(y -> y >= ylim[1], Y)
-    lasty = findlast(y -> y <= ylim[2], Y)
+    firsty = findfirst(y -> y ≥ ylim[1], Y)
+    lasty = findlast(y -> y ≤ ylim[2], Y)
     yrange = (firsty == nothing || lasty == nothing) ? (1:0) : (firsty:lasty)
     A = A[yrange, xrange]
     X = X[xrange]
@@ -126,7 +126,7 @@ function heatmap(
     max_height = height == 0 ? (width == 0 ? 0 : ceil(Int, width / data_ar)) : height
 
     # 2nrows: compensate nrows(c::HeatmapCanvas) = div(size(grid(c), 2) + 1, 2)
-    width, height, max_width, max_height = get_canvas_dimensions_for_matrix(
+    height, width, max_height, max_width = get_canvas_dimensions_for_matrix(
         HeatmapCanvas,
         2nrows,
         ncols,
@@ -149,8 +149,8 @@ function heatmap(
     end
     kw = (; kw..., colorbar = colorbar)
 
-    xs = length(X) > 0 ? [X[1], X[end]] : [0.0, 0.0]
-    ys = length(Y) > 0 ? [Y[1], Y[end]] : [0.0, 0.0]
+    xs = length(X) > 0 ? [first(X), last(X)] : zeros(2)
+    ys = length(Y) > 0 ? [first(Y), last(Y)] : zeros(2)
     plot = Plot(
         xs,
         ys,

--- a/src/interface/histogram.jl
+++ b/src/interface/histogram.jl
@@ -200,7 +200,7 @@ function histogram(
         )
         fit(Histogram, x_plot; nbins = bins, closed = closed)
     else
-        fit(Histogram, x_plot; closed = closed, filter(p -> p.first == :nbins, kw)...)
+        fit(Histogram, x_plot; closed = closed, filter(p -> p.first ≡ :nbins, kw)...)
     end
     info = if vertical && stats
         digits = 2

--- a/src/interface/histogram.jl
+++ b/src/interface/histogram.jl
@@ -41,8 +41,8 @@ function horizontal_histogram(
         pad_right = max(pad_right, a1[2], a2[2])
     end
     # compute the labels using the computed padding
-    l_str = hist.closed === :right ? "(" : "["
-    r_str = hist.closed === :right ? "]" : ")"
+    l_str = hist.closed ≡ :right ? "(" : "["
+    r_str = hist.closed ≡ :right ? "]" : ")"
     for i in eachindex(counts)
         binwidth = binwidths[i]
         val1 = float_round_log10(edges[i], binwidth)
@@ -193,7 +193,7 @@ function histogram(
     kw...,
 )
     x_plot = dropdims(x, dims = Tuple(filter(d -> size(x, d) == 1, 1:ndims(x))))
-    hist = if bins !== nothing
+    hist = if bins ≢ nothing
         Base.depwarn(
             "The keyword parameter `bins` is deprecated, use `nbins` instead",
             :histogram,
@@ -215,7 +215,7 @@ function histogram(
         ""
     end
     callable = vertical ? vertical_histogram : horizontal_histogram
-    callable(hist; info = info, filter(p -> p.first !== :nbins, kw)...)
+    callable(hist; info = info, filter(p -> p.first ≢ :nbins, kw)...)
 end
 
 @deprecate histogram(x::AbstractArray, nbins::Int; kw...) histogram(x; nbins = nbins, kw...)

--- a/src/interface/isosurface.jl
+++ b/src/interface/isosurface.jl
@@ -113,7 +113,7 @@ function isosurface!(
     cs = UserColorType[]
 
     for (i1, i2, i3) in mc.triangles
-        (i1 <= 0 || i2 <= 0 || i3 <= 0) && continue  # invalid triangle
+        (i1 ≤ 0 || i2 ≤ 0 || i3 ≤ 0) && continue  # invalid triangle
         v1 = mc.vertices[i1]
         v2 = mc.vertices[i2]
         v3 = mc.vertices[i3]

--- a/src/interface/lineplot.jl
+++ b/src/interface/lineplot.jl
@@ -94,18 +94,18 @@ function lineplot!(
         length(x) == length(y) == length(color) ||
             throw(ArgumentError("Invalid color vector"))
         for i in eachindex(color)
-            lines!(plot, x[i], y[i], z === nothing ? z : z[i], color[i])
+            lines!(plot, x[i], y[i], z ≡ nothing ? z : z[i], color[i])
         end
     else
         lines!(plot, x, y, z, color)
     end
-    (head_tail === nothing || length(x) == 0 || length(y) == 0) && return plot
+    (head_tail ≡ nothing || length(x) == 0 || length(y) == 0) && return plot
     if head_tail in (:head, :both)
         points!(
             plot,
             last(x),
             last(y),
-            z === nothing ? z : last(z),
+            z ≡ nothing ? z : last(z),
             complement(col_vec ? last(color) : color),
         )
     end
@@ -114,7 +114,7 @@ function lineplot!(
             plot,
             first(x),
             first(y),
-            z === nothing ? z : first(z),
+            z ≡ nothing ? z : first(z),
             complement(col_vec ? first(color) : color),
         )
     end
@@ -202,7 +202,7 @@ function lineplot(
     ylabel = "f(x)",
     kw...,
 )
-    y = [float(f(i)) for i in x]
+    y = float.(f.(x))
     name = name == "" ? string(nameof(f), "(x)") : name
     plot = lineplot(x, y; name = name, xlabel = xlabel, ylabel = ylabel, kw...)
 end
@@ -211,10 +211,10 @@ function lineplot(
     f::Function,
     startx::Number,
     endx::Number;
-    out_stream::Union{Nothing,IO} = nothing,
-    width::Int = out_stream_width(out_stream),
+    width::Union{Nothing,Integer} = nothing,
     kw...,
 )
+    width = something(width, DEFAULT_WIDTH[])
     diff = abs(endx - startx)
     x = startx:(diff / 3width):endx
     lineplot(f, x; width = width, kw...)
@@ -223,7 +223,7 @@ end
 lineplot(f::Function; kw...) = lineplot(f, -10, 10; kw...)
 
 function lineplot!(plot::Plot{<:Canvas}, f::Function, x::AbstractVector; name = "", kw...)
-    y = [float(f(i)) for i in x]
+    y = float.(f.(x))
     name = name == "" ? string(nameof(f), "(x)") : name
     lineplot!(plot, x, y; name = name, kw...)
 end

--- a/src/interface/scatterplot.jl
+++ b/src/interface/scatterplot.jl
@@ -88,7 +88,7 @@ function scatterplot!(
     if marker ∈ (:pixel, :auto)
         points!(plot, x, y, z, color)
     else
-        z === nothing || throw(ArgumentError("unsupported scatter with 3D data"))
+        z ≡ nothing || throw(ArgumentError("unsupported scatter with 3D data"))
         for (xi, yi, mi, ci) in zip(x, y, iterable(marker), iterable(color))
             annotate!(plot, xi, yi, char_marker(mi); color = ci)
         end

--- a/src/interface/spy.jl
+++ b/src/interface/spy.jl
@@ -111,7 +111,7 @@ function spy(
         )
         color = :auto
     end
-    width, height = get_canvas_dimensions_for_matrix(
+    height, width = get_canvas_dimensions_for_matrix(
         canvas,
         nrow,
         ncol,

--- a/src/interface/surfaceplot.jl
+++ b/src/interface/surfaceplot.jl
@@ -76,15 +76,15 @@ function surfaceplot(
     ey = extrema(y)
     eh = NaNMath.extrema(as_float(H))
 
-    if zscale === :identity
+    if zscale ≡ :identity
         ez = eh
         Z = H
     elseif zscale isa Function
         ez = zscale.(eh)
         Z = zscale.(H)
-    elseif zscale === :aspect || zscale isa NTuple{2}
+    elseif zscale ≡ :aspect || zscale isa NTuple{2}
         mh, Mh = eh
-        mz, Mz = ez = if zscale === :aspect
+        mz, Mz = ez = if zscale ≡ :aspect
             diff(ex |> collect) > diff(ey |> collect) ? ex : ey
         else
             zscale
@@ -125,7 +125,7 @@ function surfaceplot!(
     length(X) == length(Y) == length(Z) == length(H) ||
         throw(DimensionMismatch("X, Y, Z and H must have same length"))
 
-    cmapped = color === nothing
+    cmapped = color ≡ nothing
     color = (color == :auto) ? next_color!(plot) : color
 
     plot.colorbar_lim = mh, Mh = zlim == (0, 0) ? NaNMath.extrema(as_float(H)) : zlim

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -87,7 +87,7 @@ function Plot(
     projection::Union{Nothing,MVP} = nothing,
     ignored...,
 ) where {T<:GraphicsArea}
-    margin >= 0 || throw(ArgumentError("Margin must be greater than or equal to 0"))
+    margin ≥ 0 || throw(ArgumentError("Margin must be greater than or equal to 0"))
     rows = nrows(graphics)
     cols = ncols(graphics)
     labels_left = Dict{Int,String}()
@@ -96,7 +96,7 @@ function Plot(
     colors_right = Dict{Int,ColorType}()
     decorations = Dict{Symbol,String}()
     colors_deco = Dict{Symbol,ColorType}()
-    projection === nothing && (projection = MVP())
+    projection ≡ nothing && (projection = MVP())
     E = Val{is_enabled(projection)}
     F = typeof(projection.dist)
     p = Plot{T,E,F}(
@@ -200,8 +200,8 @@ function Plot(
     length(xlim) == length(ylim) == 2 ||
         throw(ArgumentError("xlim and ylim must be tuples or vectors of length 2"))
 
-    width === nothing && (width = DEFAULT_WIDTH[])
-    height === nothing && (height = DEFAULT_HEIGHT[])
+    height = something(height, DEFAULT_HEIGHT[])
+    width = something(width, DEFAULT_WIDTH[])
 
     (visible = width > 0) && (width = max(width, min_width))
     height = max(height, min_height)
@@ -214,8 +214,8 @@ function Plot(
     xscale = scale_callback(xscale)
     yscale = scale_callback(yscale)
 
-    if projection !== nothing  # 3D
-        (xscale !== identity || yscale !== identity) &&
+    if projection ≢ nothing  # 3D
+        (xscale ≢ identity || yscale ≢ identity) &&
             throw(ArgumentError("xscale or yscale are unsupported in 3D"))
 
         projection isa Symbol && (projection = MVP(x, y, z; kw...))
@@ -279,22 +279,22 @@ function Plot(
             (mx, Mx, my, My),
         )
         if unicode_exponent
-            m_x, M_x = map(v -> base_x !== nothing ? superscript(v) : v, (m_x, M_x))
-            m_y, M_y = map(v -> base_y !== nothing ? superscript(v) : v, (m_y, M_y))
+            m_x, M_x = map(v -> base_x ≢ nothing ? superscript(v) : v, (m_x, M_x))
+            m_y, M_y = map(v -> base_y ≢ nothing ? superscript(v) : v, (m_y, M_y))
         end
         if xticks
-            base_x_str = base_x === nothing ? "" : base_x * (unicode_exponent ? "" : "^")
+            base_x_str = base_x ≡ nothing ? "" : base_x * (unicode_exponent ? "" : "^")
             label!(plot, :bl, base_x_str * m_x, color = BORDER_COLOR[])
             label!(plot, :br, base_x_str * M_x, color = BORDER_COLOR[])
         end
         if yticks
-            base_y_str = base_y === nothing ? "" : base_y * (unicode_exponent ? "" : "^")
+            base_y_str = base_y ≡ nothing ? "" : base_y * (unicode_exponent ? "" : "^")
             label!(plot, :l, nrows(canvas), base_y_str * m_y, color = BORDER_COLOR[])
             label!(plot, :l, 1, base_y_str * M_y, color = BORDER_COLOR[])
         end
     end
     if grid
-        if xscale === identity && yscale === identity
+        if xscale ≡ identity && yscale ≡ identity
             if my < 0 < My
                 for i in range(mx, stop = Mx, length = width * x_pixel_per_char(C))
                     points!(plot, i, 0.0, nothing)
@@ -689,7 +689,7 @@ function _show(io::IO, print_nc, print_col, p::Plot)
     nc = ncols(c)
     p_width = nc + 2  # left corner + border length (number of canvas cols) + right corner
 
-    bmap = BORDERMAP[p.border === :none && c isa BrailleCanvas ? :bnone : p.border]
+    bmap = BORDERMAP[p.border ≡ :none && c isa BrailleCanvas ? :bnone : p.border]
     bc = BORDER_COLOR[]
 
     # get length of largest strings to the left and right
@@ -951,12 +951,12 @@ function png_image(
 
     default_fg_color = rgba(fg_color)
     default_bg_color = rgba(bg_color, transparent ? 0.0 : 1.0)
-    bbox = if bounding_box !== nothing
+    bbox = if bounding_box ≢ nothing
         rgba(ansi_color(bounding_box))
     else
         bounding_box
     end
-    bbox_glyph = if bounding_box_glyph !== nothing
+    bbox_glyph = if bounding_box_glyph ≢ nothing
         rgba(ansi_color(bounding_box_glyph))
     else
         bounding_box_glyph
@@ -1006,7 +1006,7 @@ function png_image(
     lgcols = sizehint!([RGBA{Float32}[]], nr)
     r = 1
     for (fchar, gchar, fcol, gcol) in zip(fchars, gchars, fcolors, gcolors)
-        if fchar === '\n'
+        if fchar ≡ '\n'
             r += 1
             push!(lfchars, Char[])
             push!(lgchars, Char[])
@@ -1023,13 +1023,13 @@ function png_image(
     # render image
     face = nothing
     for font_name in filter(!isnothing, (font, "JuliaMono", fallback_font()))
-        if (ft = FreeTypeAbstraction.findfont(font_name)) !== nothing
+        if (ft = FreeTypeAbstraction.findfont(font_name)) ≢ nothing
             face = ft
             break
         end
     end
 
-    kr = ASPECT_RATIO
+    kr = ASPECT_RATIO[]
     kc = kr / 2
 
     img = fill(

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -305,8 +305,6 @@ function Plot(
                     points!(plot, 0.0, i, nothing)
                 end
             end
-        else
-            # TODO: maybe draw `log` scale grid lines 
         end
     end
 

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -166,11 +166,11 @@ cube_corners(mx, Mx, my, My, mz, Mz) = [
 
 function view_matrix(center, distance, elevation, azimuth, up)
     up_str = string(up)
-    shift = if (up_axis = Symbol(up_str[end])) === :x
+    shift = if (up_axis = Symbol(up_str[end])) ≡ :x
         0
-    elseif up_axis === :y
+    elseif up_axis ≡ :y
         1
-    elseif up_axis === :z
+    elseif up_axis ≡ :z
         2
     else
         throw(ArgumentError("up=$up not understood"))
@@ -235,7 +235,7 @@ struct MVP{E,T}
         @assert -90 ≤ elevation ≤ 90
 
         F = float(eltype(z))
-        is_ortho = projection === :orthographic
+        is_ortho = projection ≡ :orthographic
         ctr, mini, maxi, len, diag = ctr_len_diag(x, y, z)
 
         # half the diagonal (cam distance to the center)
@@ -276,21 +276,21 @@ is_enabled(::MVP{Val{false}}) = false
 is_enabled(::MVP{Val{true}}) = true
 
 function transform_matrix(t::MVP{E,T}, n::Symbol)::SMatrix{4,4,T} where {E,T}
-    if n === :user
+    if n ≡ :user
         t.mvp_mat
-    elseif n === :orthographic
+    elseif n ≡ :orthographic
         t.mvp_ortho_mat
-    elseif n === :perspective
+    elseif n ≡ :perspective
         t.mvp_persp_mat
     end
 end
 
 function is_ortho(t::MVP, n::Symbol)::Bool
-    if n === :user
+    if n ≡ :user
         t.ortho
-    elseif n === :orthographic
+    elseif n ≡ :orthographic
         true
-    elseif n === :perspective
+    elseif n ≡ :perspective
         false
     end
 end

--- a/test/tst_common.jl
+++ b/test/tst_common.jl
@@ -177,25 +177,18 @@ end
     @test UnicodePlots.scale_callback(x -> x)(1) === 1
     @test UnicodePlots.scale_callback(Scale(π))(1) ≈ π
 
-    @test UnicodePlots.out_stream_width(nothing) == 40
-    @test UnicodePlots.out_stream_height(nothing) == 15
+    h, w = displaysize()
+    @test UnicodePlots.out_stream_height() == h
+    @test UnicodePlots.out_stream_width() == w
 
     @test UnicodePlots.superscript("-10") == "⁻¹⁰"
     @test UnicodePlots.superscript("+2") == "⁺²"
 
     @test_throws AssertionError UnicodePlots.default_size!(width = 8, height = 8)
 
-    UnicodePlots.default_size!(height = 30)
-    @test UnicodePlots.DEFAULT_WIDTH[] == 80
-    @test UnicodePlots.DEFAULT_HEIGHT[] == 30
-
-    UnicodePlots.default_size!(width = 64)
-    @test UnicodePlots.DEFAULT_WIDTH[] == 64
-    @test UnicodePlots.DEFAULT_HEIGHT[] == 24
-
-    UnicodePlots.default_size!()
-    @test UnicodePlots.DEFAULT_WIDTH[] == 40
-    @test UnicodePlots.DEFAULT_HEIGHT[] == 15
+    @test UnicodePlots.default_size!(height = 30) == (30, 80)
+    @test UnicodePlots.default_size!(width = 64) == (24, 64)
+    @test UnicodePlots.default_size!() == (15, 40)
 end
 
 @testset "docs" begin

--- a/test/tst_common.jl
+++ b/test/tst_common.jl
@@ -184,11 +184,11 @@ end
     @test UnicodePlots.superscript("-10") == "⁻¹⁰"
     @test UnicodePlots.superscript("+2") == "⁺²"
 
-    @test_throws AssertionError UnicodePlots.default_size!(width = 8, height = 8)
+    @test_throws AssertionError default_size!(width = 8, height = 8)
 
-    @test UnicodePlots.default_size!(height = 30) == (30, 80)
-    @test UnicodePlots.default_size!(width = 64) == (24, 64)
-    @test UnicodePlots.default_size!() == (15, 40)
+    @test default_size!(height = 30) == (30, 80)
+    @test default_size!(width = 64) == (24, 64)
+    @test default_size!() == (15, 40)
 end
 
 @testset "docs" begin


### PR DESCRIPTION
- fix embarrassing swap of width and height in `out_stream_size`;
- make `default_size!` return `(h, w)`, and export the symbol;
- enforce uppercasing `const` globals (convention, readability);
- code style modernization (mostly unicode syms).

Should be backward compatible, bug fix version.

Nightly failure is unrelated (https://github.com/JuliaStats/StatsBase.jl/pull/792 merged but not yet released in `StatsBase`), following https://github.com/JuliaLang/julia/pull/45576.