### PR TITLE
fix custom registered scheme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,6 @@ Unitful = "1"
 julia = "1.6"
 
 [extras]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
@@ -48,4 +47,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
-test = ["ColorTypes", "ImageMagick", "Random", "ReferenceTests", "StableRNGs", "Test", "TimerOutputs"]
+test = ["ImageMagick", "Random", "ReferenceTests", "StableRNGs", "Test", "TimerOutputs"]

--- a/src/common.jl
+++ b/src/common.jl
@@ -485,7 +485,7 @@ function ansi_4bit_to_8bit(c::UInt8)::UInt8
     r + (q > 0x0 ? 0x8 : 0x0)
 end
 
-c256(c::AbstractFloat) = round(Int, 255c)
+c256(c::AbstractFloat) = round(UInt32, 255c)
 c256(c::Integer) = c
 
 # `ColorType` conversion - colormaps
@@ -547,7 +547,7 @@ multiple_series_defaults(y::AbstractMatrix, kw, start) = (
 )
 
 function colormap_callback(cmap::Symbol)
-    cdata = getfield(ColorSchemes, cmap)
+    cdata = ColorSchemes.colorschemes[cmap]
     (z, minz, maxz) -> begin
         isfinite(z) || return nothing
         get(

--- a/src/interface/barplot.jl
+++ b/src/interface/barplot.jl
@@ -66,7 +66,7 @@ function barplot(
         throw(DimensionMismatch("the given vectors must be of the same length"))
     minimum(heights) ≥ 0 || throw(ArgumentError("all values have to be ≥ 0"))
 
-    if any(occursin('\n', t) for t ∈ text)
+    if any(map(t -> occursin('\n', t), text))
         _text = eltype(text)[]
         _heights = eltype(heights)[]
         for (t, h) ∈ zip(text, heights)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ include("tst_world_age.jl")
 
 import Dates: Date, Day
 import Random: seed!
+import ColorSchemes
 import FileIO
 
 using ReferenceTests


### PR DESCRIPTION
Access `ColorSchemes` colormap through `ColorSchemes.colorschemes`'s Dict and not by const Symbol.
Allows using a custom registered cmap.
Added coverage test.