### PR TITLE
enhance error message for big amplitude

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -132,9 +132,7 @@ function validate_input(
 )
     length(x) == length(y) == length(z) ||
         throw(DimensionMismatch("`x`, `y` and `z` must have same length"))
-    idx = BitVector(map(x, y, z) do i, j, k
-        isfinite(i) && isfinite(j) && isfinite(k)
-    end)
+    idx = BitVector(map((i, j, k) -> isfinite(i) && isfinite(j) && isfinite(k), x, y, z))
     x[idx], y[idx], z[idx]
 end
 
@@ -144,9 +142,7 @@ function validate_input(
     z::Nothing,
 )
     length(x) == length(y) || throw(DimensionMismatch("`x` and `y` must have same length"))
-    idx = BitVector(map(x, y) do i, j
-        isfinite(i) && isfinite(j)
-    end)
+    idx = BitVector(map((i, j) -> isfinite(i) && isfinite(j), x, y))
     x[idx], y[idx], z
 end
 

--- a/test/tst_common.jl
+++ b/test/tst_common.jl
@@ -1,19 +1,3 @@
-@testset "plotting_range" begin
-    @testset "types" begin
-        @test UnicodePlots.plotting_range(0, 1) ≡ (0.0, 1.0)
-        @test UnicodePlots.plotting_range(0.0, 1) ≡ (0.0, 1.0)
-        @test UnicodePlots.plotting_range(0, 1.0f0) ≡ (0.0, 1.0f0)
-        @test UnicodePlots.plotting_range(0x0, 0x1) ≡ (0.0, 1.0)
-    end
-
-    @test UnicodePlots.plotting_range(0.0001, 0.002) ≡ (0.0, 0.01)
-    @test UnicodePlots.plotting_range(0.001, 0.02) ≡ (0.0, 0.1)
-    @test UnicodePlots.plotting_range(0.01, 0.2) ≡ (0.0, 1.0)
-    @test UnicodePlots.plotting_range(0.1, 2.0) ≡ (0.0, 10.0)
-    @test UnicodePlots.plotting_range(0, 2) ≡ (0.0, 10.0)
-    @test UnicodePlots.plotting_range(0, 5) ≡ (0.0, 10.0)
-end
-
 @testset "plotting_range_narrow" begin
     @testset "types" begin
         @test UnicodePlots.plotting_range_narrow(0, 1) ≡ (0.0, 1.0)
@@ -22,6 +6,14 @@ end
         @test UnicodePlots.plotting_range_narrow(0x0, 0x1) ≡ (0.0, 1.0)
     end
 
+    @test_throws DomainError UnicodePlots.plotting_range_narrow(
+        nextfloat(-Inf),
+        prevfloat(Inf),
+    )
+    @test UnicodePlots.plotting_range_narrow(nextfloat(-Inf32), prevfloat(Inf32)) ≡
+          (-Inf32, Inf32)
+    @test UnicodePlots.plotting_range_narrow(nextfloat(-Inf16), prevfloat(Inf16)) ≡
+          (-Inf16, Inf16)
     @test UnicodePlots.plotting_range_narrow(0.0001, 0.002) ≡ (0.0, 0.002)
     @test UnicodePlots.plotting_range_narrow(0.001, 0.02) ≡ (0.0, 0.02)
     @test UnicodePlots.plotting_range_narrow(0.01, 0.2) ≡ (0.0, 0.2)

--- a/test/tst_issues.jl
+++ b/test/tst_issues.jl
@@ -42,10 +42,16 @@
         @test lineplot(0.01:10, 0.01:10, xscale = :log10, yscale = :log10) isa Plot
     end
 
-    @testset "Float input (#277)" begin
+    @testset "float input (#277)" begin
         for FX ∈ (Float16, Float32, Float64), FY ∈ (Float16, Float32, Float64)
             @test lineplot(FX[-1, 2], FY[-1, 9]) isa Plot
         end
         @test barplot(["Paris", "Madrid"], Float32[2.2, 8.4]; maximum = 10.0f0) isa Plot
+    end
+
+    @testset "invalid data (#297)" begin
+        @test_throws DomainError lineplot([nextfloat(-Inf), prevfloat(+Inf)])
+        @test lineplot([nextfloat(-Inf32), prevfloat(+Inf32)]) isa Plot
+        @test lineplot([nextfloat(-Inf16), prevfloat(+Inf16)]) isa Plot
     end
 end


### PR DESCRIPTION
Fix https://github.com/JuliaPlots/UnicodePlots.jl/issues/297.

```julia
julia> lineplot([-1.739368555288356e308, 1.291068489563134e307])
ERROR: DomainError with Invalid plotting range: (-1.739368555288356e308, 1.291068489563134e307):

Stacktrace:
  [1] plotting_range_narrow
    @ [...]/UnicodePlots.jl/src/common.jl:346 [inlined]
  [2] extend_limits(vec::Vector{Float64}, lims::Tuple{Int64, Int64}, scale::typeof(identity))
    @ UnicodePlots [...]/UnicodePlots.jl/src/common.jl:370
```

Don't error on large amplitude for weaker precision floats `lineplot([nextfloat(-Inf32), prevfloat(+Inf32)])`:
```julia
julia> lineplot([nextfloat(-Inf32), prevfloat(+Inf32)])
        ┌────────────────────────────────────────┐ 
    Inf │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
   -Inf │⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀│ 
        └────────────────────────────────────────┘ 
        ⠀1⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀2⠀ 
```

cc @KristofferC.