### PR TITLE
README: Fix two section headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ julia> Pkg.add("UnicodePlots")
   ```
 </details>
 
-##### Know Issues
+##### Known issues
 <details>
   <summary></a><b>...</b></summary><br>
 
@@ -630,7 +630,7 @@ The method `label!` is responsible for the setting all the textual decorations o
   
 </details>
 
-##### Low-level Interface
+##### Low-level interface
 <details>
   <summary></a><b>...</b></summary><br>
 

--- a/docs/gen_docs.jl
+++ b/docs/gen_docs.jl
@@ -591,7 +591,7 @@ $(indent(examples.isosurface))
   ```
 </details>
 
-##### Know Issues
+##### Known issues
 <details>
   $(summary(nothing))
 
@@ -620,7 +620,7 @@ $(methods)
 $(indent(kw_description))
 </details>
 
-##### Low-level Interface
+##### Low-level interface
 <details>
   $(summary(nothing))
 


### PR DESCRIPTION
- Typo: "Know issues" → "Known issues"
- Normalize section heading capitalization to Sentence case