### PR TITLE
fix `SVector` inferrability

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -415,9 +415,10 @@ end
 
 is_auto(lims) = all(iszero, lims)
 
-autolims(lims) = is_auto(lims) ? SVector(-1.0, 1.0) : SVector(as_float(lims))
+# NOTE: we need `SVector{2}(v)` for compiler inferrability, not `Svector(v)` !
+autolims(lims) = is_auto(lims) ? SVector(-1.0, 1.0) : SVector{2}(as_float(lims))
 autolims(lims, vec::AbstractVector) =
-    is_auto(lims) && length(vec) > 0 ? SVector(extrema(vec)) : SVector(as_float(lims))
+    is_auto(lims) && length(vec) > 0 ? SVector{2}(extrema(vec)) : SVector{2}(as_float(lims))
 
 scale_callback(scale::Symbol) = FSCALES[scale]
 scale_callback(scale::Function) = scale

--- a/src/interface/heatmap.jl
+++ b/src/interface/heatmap.jl
@@ -86,7 +86,6 @@ function heatmap(
     end .+ xoffset
 
     # set the axis limits automatically
-
     ylim = autolims(ylim, Y)
     xlim = autolims(xlim, X)
 

--- a/src/volume.jl
+++ b/src/volume.jl
@@ -272,9 +272,9 @@ struct MVP{E,T}
     end
 end
 
-create_MVP(::Nothing, args...; kw...) = (warn_on_lost_kw(kw); MVP())
 create_MVP(projection::Symbol, args...; kw...) = MVP(args...; projection, kw...)
-create_MVP(projection::MVP, args...; kw...) = (warn_on_lost_kw(kw); projection)
+create_MVP(projection::MVP, args...; _...) = projection  # NOTE: kw are expected to be lost (see Plots)
+create_MVP(::Nothing, args...; _...) = MVP()  # NOTE: kw are expected to be lost (see Plots)
 
 @inline is_enabled(::MVP{Val{false}}) = false
 @inline is_enabled(::MVP{Val{true}}) = true

--- a/test/tst_common.jl
+++ b/test/tst_common.jl
@@ -40,6 +40,11 @@ end
     @test UnicodePlots.is_auto([0, 0])
     @test !UnicodePlots.is_auto((-1, 1))
     @test !UnicodePlots.is_auto([-1, 1])
+
+    # `SVector` inferrability
+    @test UnicodePlots.autolims([-3, 2]) == [-3, 2]
+    @test UnicodePlots.autolims([-3, 2], 1:10) == [-3, 2]
+    @test UnicodePlots.autolims([0, 0], 1:10) == [1, 10]
 end
 
 @testset "bordermap" begin


### PR DESCRIPTION
Bug introduced by https://github.com/JuliaPlots/UnicodePlots.jl/pull/327.