### PR TITLE
adapt to new lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'  # older supported LTS
-          - '1.10'  # latest LTS
+          - '1.10'  # oldest supported LTS (declared in Project.toml)
           - '1'
         experimental:
           - false

--- a/Project.toml
+++ b/Project.toml
@@ -16,10 +16,24 @@ MarchingCubes = "299715c1-40a9-479a-aaf9-4a633d36f717"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+
+[weakdeps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+FreeType = "b38be410-82b0-50bf-ab77-7b57e271db43"
+ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[extensions]
+FreeTypeExt = ["FileIO", "FreeType"]
+ImageInTerminalExt = "ImageInTerminal"
+IntervalSetsExt = "IntervalSets"
+TermExt = "Term"
+UnitfulExt = "Unitful"
 
 [compat]
 ColorSchemes = "^3.19"
@@ -36,20 +50,12 @@ MarchingCubes = "0.1"
 NaNMath = "0.3, 1"
 PrecompileTools = "1"
 Printf = "1"
-Requires = "1"
 SparseArrays = "1"
 StaticArrays = "1"
-StatsBase = "0.33, 0.34"
+StatsBase = "0.33 - 0.34"
 Term = "2"
 Unitful = "1"
-julia = "1.6"
-
-[extensions]
-FreeTypeExt = ["FileIO", "FreeType"]
-ImageInTerminalExt = "ImageInTerminal"
-IntervalSetsExt = "IntervalSets"
-TermExt = "Term"
-UnitfulExt = "Unitful"
+julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
@@ -70,11 +76,3 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
 test = ["Aqua", "DataFrames", "FileIO", "FreeType", "ImageInTerminal", "ImageMagick", "IntervalSets", "Random", "ReferenceTests", "StableRNGs", "Term", "Test", "TestImages", "TimerOutputs", "Unitful"]
-
-[weakdeps]
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-FreeType = "b38be410-82b0-50bf-ab77-7b57e271db43"
-ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
-IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
-Term = "22787eb5-b846-44ae-b979-8e399b8463ab"
-Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/ext/FreeTypeExt.jl
+++ b/ext/FreeTypeExt.jl
@@ -4,10 +4,11 @@
 module FreeTypeExt
 
 import UnicodePlots
-UnicodePlots.@ext_imp_use :using FreeType
-UnicodePlots.@ext_imp_use :import FileIO
+import FileIO
+
 using StaticArrays
 using ColorTypes
+using FreeType
 
 const REGULAR_STYLES = "regular", "normal", "medium", "standard", "roman", "book"
 const FT_LIB = FT_Library[C_NULL]

--- a/ext/ImageInTerminalExt.jl
+++ b/ext/ImageInTerminalExt.jl
@@ -1,7 +1,8 @@
 module ImageInTerminalExt
 
+import ImageInTerminal
 import UnicodePlots
-UnicodePlots.@ext_imp_use :import ImageInTerminal
+
 using ColorTypes
 
 UnicodePlots.sixel_encode(args...; kw...) = ImageInTerminal.sixel_encode(args...; kw...)  # COV_EXCL_LINE

--- a/ext/IntervalSetsExt.jl
+++ b/ext/IntervalSetsExt.jl
@@ -1,7 +1,7 @@
 module IntervalSetsExt
 
-import UnicodePlots: UnicodePlots, Plot, Canvas
-UnicodePlots.@ext_imp_use :import IntervalSets
+import UnicodePlots
+import IntervalSets
 
 function interval_range(x::IntervalSets.AbstractInterval, length, step)
     if length ≡ nothing && step ≡ nothing
@@ -19,7 +19,7 @@ UnicodePlots.lineplot(
 ) = UnicodePlots.lineplot(interval_range(x, length, step), f; kw...)
 
 UnicodePlots.lineplot!(
-    plot::Plot{<:Canvas},
+    plot::UnicodePlots.Plot{<:UnicodePlots.Canvas},
     x::IntervalSets.AbstractInterval,
     f::Function;
     length = nothing,

--- a/ext/TermExt.jl
+++ b/ext/TermExt.jl
@@ -1,7 +1,7 @@
 module TermExt
 
-import UnicodePlots: UnicodePlots, Plot
-UnicodePlots.@ext_imp_use :import Term
+import UnicodePlots
+import Term
 
 function UnicodePlots.panel(p; kw...)
     p.margin[] = p.padding[] = 0  # make plots more compact
@@ -11,7 +11,7 @@ end
 
 UnicodePlots.gridplot(plots::Union{AbstractVector,Tuple}; kw...) =
     UnicodePlots.gridplot(plots...; kw...)
-UnicodePlots.gridplot(plots::Plot...; kw...) =
+UnicodePlots.gridplot(plots::UnicodePlots.Plot...; kw...) =
     Term.grid(map(UnicodePlots.panel, plots); kw...)
 
 end  # module

--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -1,7 +1,7 @@
 module UnitfulExt
 
 import UnicodePlots: UnicodePlots, KEYWORDS, Plot, Canvas, unitless
-UnicodePlots.@ext_imp_use :import Unitful Quantity RealOrRealQuantity ustrip unit
+import Unitful: Quantity, RealOrRealQuantity, ustrip, unit
 
 function unit_str(x, fancy)
     io = IOContext(PipeBuffer(), :fancy_exponent => fancy)

--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -111,8 +111,6 @@ include("interface/boxplot.jl")
 include("interface/polarplot.jl")
 include("interface/imageplot.jl")
 
-isdefined(Base, :get_extension) || import Requires: @require
-
 function __init__()
     if (terminal_24bit() || forced_24bit()) && !forced_8bit()
         truecolors!()
@@ -120,25 +118,6 @@ function __init__()
     else
         colors256!()
         faintcolors!()
-    end
-    @static if !isdefined(Base, :get_extension)  # COV_EXCL_LINE
-        @require ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254" include(
-            joinpath("..", "ext", "ImageInTerminalExt.jl"),
-        )
-        @require FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549" begin
-            @require FreeType = "b38be410-82b0-50bf-ab77-7b57e271db43" begin
-                include(joinpath("..", "ext", "FreeTypeExt.jl"))
-            end
-        end
-        @require IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953" include(
-            joinpath("..", "ext", "IntervalSetsExt.jl"),
-        )
-        @require Term = "22787eb5-b846-44ae-b979-8e399b8463ab" include(
-            joinpath("..", "ext", "TermExt.jl"),
-        )
-        @require Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d" include(
-            joinpath("..", "ext", "UnitfulExt.jl"),
-        )
     end
     nothing
 end

--- a/src/common.jl
+++ b/src/common.jl
@@ -197,29 +197,6 @@ const COLOR_CYCLE = Ref(COLOR_CYCLE_FAINT)
 const BORDER_COLOR = Ref(:dark_gray)
 
 ############################################################################################
-# misc
-
-"""
-    @ext_imp_use :import Unitful Quantity RealOrRealQuantity
-
-Equivalent to the following, for `Requires` or weak deps:
-```
-@static if isdefined(Base, :get_extension)
-    import Unitful: Quantity, RealOrRealQuantity
-else
-    import ..Unitful: Quantity, RealOrRealQuantity
-end
-```
-"""
-macro ext_imp_use(imp_use::QuoteNode, mod::Symbol, args...)
-    dots = ntuple(_ -> :., isdefined(Base, :get_extension) ? 1 : 3)
-    ex = if length(args) > 0
-        Expr(:(:), Expr(dots..., mod), Expr.(:., args)...)
-    else
-        Expr(dots..., mod)
-    end
-    Expr(imp_use.value, ex) |> esc
-end
 
 const FSCALES = (identity = identity, ln = log, log2 = log2, log10 = log10)  # forward
 const ISCALES = (identity = identity, ln = exp, log2 = exp2, log10 = exp10)  # inverse

--- a/test/tst_quality.jl
+++ b/test/tst_quality.jl
@@ -4,7 +4,7 @@
         UnicodePlots;
         ambiguities = false,
         deps_compat = false,
-        stale_deps = !isdefined(Base, :get_extension),  # issue with `Requires` not used when weak deps are enabled
+        stale_deps = false,
     )
     Aqua.test_ambiguities(UnicodePlots)
 end


### PR DESCRIPTION
- drop `Requires` and use only extensions;
- support only LTS (per this [PSA](https://discourse.julialang.org/t/julia-v1-11-0-has-been-released-and-v1-10-is-now-lts/121064)), hence `julia >= 1.10`.