### PR TITLE
fix precompilation

### DIFF
--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -114,7 +114,7 @@ include("interface/imageplot.jl")
 function __init__()
     forced_24bit() && return init_24bit()
     forced_8bit() && return init_8bit()
-    Base.get_have_truecolor() ? init_24bit() : init_8bit()
+    get_have_truecolor() ? init_24bit() : init_8bit()
     nothing
 end
 

--- a/src/UnicodePlots.jl
+++ b/src/UnicodePlots.jl
@@ -112,18 +112,15 @@ include("interface/polarplot.jl")
 include("interface/imageplot.jl")
 
 function __init__()
-    if (terminal_24bit() || forced_24bit()) && !forced_8bit()
-        truecolors!()
-        USE_LUT[] ? brightcolors!() : faintcolors!()
-    else
-        colors256!()
-        faintcolors!()
-    end
+    forced_24bit() && return init_24bit()
+    forced_8bit() && return init_8bit()
+    Base.get_have_truecolor() ? init_24bit() : init_8bit()
     nothing
 end
 
 # COV_EXCL_START
 function precompile_workload(io::IO = IOContext(devnull, :color => Base.get_have_color()))
+    __init__()
     surf(x, y) = sinc(√(x^2 + y^2))
     for T in (  # most common types
         Float64,

--- a/src/common.jl
+++ b/src/common.jl
@@ -252,6 +252,14 @@ function init_8bit()
     nothing
 end
 
+get_have_truecolor() =
+    if isdefined(Base, :get_have_truecolor)
+        Base.get_have_truecolor()
+    else
+        # see gist.github.com/XVilka/8346728#checking-for-colorterm
+        lowercase(get(ENV, "COLORTERM", "")) ∈ ("24bit", "truecolor")
+    end
+
 # specific to UnicodePlots
 forced_24bit() = lowercase(get(ENV, "UP_COLORMODE", "")) ∈ ("24", "24bit", "truecolor")
 forced_8bit() = lowercase(get(ENV, "UP_COLORMODE", "")) ∈ ("8", "8bit")

--- a/src/common.jl
+++ b/src/common.jl
@@ -240,8 +240,17 @@ end
 brightcolors!() = COLOR_CYCLE[] = COLOR_CYCLE_BRIGHT
 faintcolors!() = COLOR_CYCLE[] = COLOR_CYCLE_FAINT
 
-# see gist.github.com/XVilka/8346728#checking-for-colorterm
-terminal_24bit() = lowercase(get(ENV, "COLORTERM", "")) ∈ ("24bit", "truecolor")
+function init_24bit()
+    truecolors!()
+    USE_LUT[] ? brightcolors!() : faintcolors!()
+    nothing
+end
+
+function init_8bit()
+    colors256!()
+    faintcolors!()
+    nothing
+end
 
 # specific to UnicodePlots
 forced_24bit() = lowercase(get(ENV, "UP_COLORMODE", "")) ∈ ("24", "24bit", "truecolor")


### PR DESCRIPTION
`__init__` must be called in `precompile_workload`.

Also, use `Base.get_have_truecolor` if possible.